### PR TITLE
[feature] add RGB565 buffer support

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -38,7 +38,13 @@ use wayland_protocols::wlr::unstable::screencopy::v1::client::{
     zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1,
 };
 
-use crate::convert::create_converter;
+use crate::convert::{create_copy_converter, create_in_place_converter};
+
+#[derive(Debug)]
+pub enum FrameData {
+    InPlace(MmapMut),
+    Copied(Vec<u8>),
+}
 
 /// Type of frame supported by the compositor. For now we only support Argb8888, Xrgb8888, and
 /// Xbgr8888.
@@ -65,7 +71,7 @@ enum FrameState {
 pub struct FrameCopy {
     pub frame_format: FrameFormat,
     pub frame_color_type: ColorType,
-    pub frame_mmap: MmapMut,
+    pub frame_data: FrameData,
 }
 
 /// Struct to store region capture details.
@@ -206,6 +212,7 @@ pub fn capture_output_frame(
                     | wl_shm::Format::Argb8888
                     | wl_shm::Format::Xrgb8888
                     | wl_shm::Format::Xbgr8888
+                    | wl_shm::Format::Rgb565
             )
         })
         .copied();
@@ -257,10 +264,16 @@ pub fn capture_output_frame(
                     // Create a writeable memory map backed by a mem_file.
                     let mut frame_mmap = unsafe { MmapMut::map_mut(&mem_file)? };
                     let data = &mut *frame_mmap;
-                    let frame_color_type = if let Some(converter) =
-                        create_converter(frame_format.format)
+                    let (frame_color_type, frame_data) = if let Some(converter) =
+                        create_in_place_converter(frame_format.format)
                     {
-                        converter.convert_inplace(data)
+                        (
+                            converter.convert_in_place(data),
+                            FrameData::InPlace(frame_mmap),
+                        )
+                    } else if let Some(converter) = create_copy_converter(frame_format.format) {
+                        let (color_type, frame_vec) = converter.convert_copy(data);
+                        (color_type, FrameData::Copied(frame_vec))
                     } else {
                         log::error!("Unsupported buffer format: {:?}", frame_format.format);
                         log::error!("You can send a feature request for the above format to the mailing list for wayshot over at https://sr.ht/~shinyzenith/wayshot.");
@@ -269,7 +282,7 @@ pub fn capture_output_frame(
                     return Ok(FrameCopy {
                         frame_format,
                         frame_color_type,
-                        frame_mmap,
+                        frame_data,
                     });
                 }
             }
@@ -360,10 +373,14 @@ pub fn write_to_file(
         "Writing to disk with encoding format: {:#?}",
         encoding_format
     );
+    let frame_slice: &[u8] = match &frame_copy.frame_data {
+        FrameData::InPlace(x) => x,
+        FrameData::Copied(x) => x,
+    };
     match encoding_format {
         EncodingFormat::Jpg => {
             JpegEncoder::new(&mut output_file).write_image(
-                &frame_copy.frame_mmap,
+                frame_slice,
                 frame_copy.frame_format.width,
                 frame_copy.frame_format.height,
                 frame_copy.frame_color_type,
@@ -372,7 +389,7 @@ pub fn write_to_file(
         }
         EncodingFormat::Png => {
             PngEncoder::new(&mut output_file).write_image(
-                &frame_copy.frame_mmap,
+                frame_slice,
                 frame_copy.frame_format.width,
                 frame_copy.frame_format.height,
                 frame_copy.frame_color_type,
@@ -384,7 +401,7 @@ pub fn write_to_file(
                 let mut data = Vec::with_capacity(
                     (3 * frame_copy.frame_format.width * frame_copy.frame_format.height) as _,
                 );
-                for chunk in frame_copy.frame_mmap.chunks_exact(4) {
+                for chunk in frame_slice.chunks_exact(4) {
                     data.extend_from_slice(&chunk[..3]);
                 }
                 data

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,9 +1,14 @@
 use image::ColorType;
 use wayland_client::protocol::wl_shm;
 
-pub trait Convert {
+pub trait ConvertInPlace {
     /// Convert raw image data into output type, return said type
-    fn convert_inplace(&self, data: &mut [u8]) -> ColorType;
+    fn convert_in_place(&self, data: &mut [u8]) -> ColorType;
+}
+
+pub trait ConvertCopy {
+    /// Convert raw image data into output type, return said type
+    fn convert_copy(&self, data: &[u8]) -> (ColorType, Vec<u8>);
 }
 
 #[derive(Default)]
@@ -15,12 +20,15 @@ struct ConvertNone {}
 #[derive(Default)]
 struct ConvertRGB8 {}
 
+#[derive(Default)]
+struct ConvertRGB565 {}
+
 const SHIFT10BITS_1: u32 = 20;
 const SHIFT10BITS_2: u32 = 10;
 
 /// Creates format converter based of input format, return None if conversion
 /// isn't possible. Conversion is happening inplace.
-pub fn create_converter(format: wl_shm::Format) -> Option<Box<dyn Convert>> {
+pub fn create_in_place_converter(format: wl_shm::Format) -> Option<Box<dyn ConvertInPlace>> {
     match format {
         wl_shm::Format::Xbgr8888 | wl_shm::Format::Abgr8888 => {
             Some(Box::new(ConvertNone::default()))
@@ -35,14 +43,21 @@ pub fn create_converter(format: wl_shm::Format) -> Option<Box<dyn Convert>> {
     }
 }
 
-impl Convert for ConvertNone {
-    fn convert_inplace(&self, _data: &mut [u8]) -> ColorType {
+pub fn create_copy_converter(format: wl_shm::Format) -> Option<Box<dyn ConvertCopy>> {
+    match format {
+        wl_shm::Format::Rgb565 => Some(Box::new(ConvertRGB565::default())),
+        _ => None,
+    }
+}
+
+impl ConvertInPlace for ConvertNone {
+    fn convert_in_place(&self, _data: &mut [u8]) -> ColorType {
         ColorType::Rgba8
     }
 }
 
-impl Convert for ConvertRGB8 {
-    fn convert_inplace(&self, data: &mut [u8]) -> ColorType {
+impl ConvertInPlace for ConvertRGB8 {
+    fn convert_in_place(&self, data: &mut [u8]) -> ColorType {
         for chunk in data.chunks_exact_mut(4) {
             chunk.swap(0, 2);
         }
@@ -55,8 +70,8 @@ fn convert10_to_8(color: u32) -> u8 {
     ((color >> 2) & 255) as u8
 }
 
-impl Convert for ConvertBGR10 {
-    fn convert_inplace(&self, data: &mut [u8]) -> ColorType {
+impl ConvertInPlace for ConvertBGR10 {
+    fn convert_in_place(&self, data: &mut [u8]) -> ColorType {
         for chunk in data.chunks_exact_mut(4) {
             let pixel = ((chunk[3] as u32) << 24)
                 | ((chunk[2] as u32) << 16)
@@ -71,5 +86,23 @@ impl Convert for ConvertBGR10 {
             chunk[3] = 255;
         }
         ColorType::Rgba8
+    }
+}
+
+impl ConvertCopy for ConvertRGB565 {
+    fn convert_copy(&self, data: &[u8]) -> (ColorType, Vec<u8>) {
+        let mut out = Vec::with_capacity(2 * data.len());
+        for chunk in data.chunks_exact(2) {
+            let src = (chunk[1] as u16) << 8 | (chunk[0] as u16);
+            let r5 = ((src >> 11) & 0x1f) as u8;
+            let g6 = ((src >> 5) & 0x3f) as u8;
+            let b5 = (src & 0x1f) as u8;
+            let r8 = (r5 << 3) | (r5 >> 2);
+            let g8 = (g6 << 2) | (g6 >> 4);
+            let b8 = (b5 << 3) | (b5 >> 2);
+            let dst = [r8, g8, b8, 255];
+            out.extend_from_slice(&dst);
+        }
+        (ColorType::Rgba8, out)
     }
 }


### PR DESCRIPTION
This makes it possible to take screenshots if the compositor renders to an RGB565 buffer.

I am submitting this PR because I already wrote the patch, and there's a chance it matches the project goals. However, as essentially no wlroots-based compositors currently allow rendering to RGB565 buffers, what with XBGR8888 or higher formats being preferable in almost all cases, I will understand and not be surprised if you close this.

I tested this with a [branch of sway](https://github.com/mstoeckl/sway/tree/extra-bit-depths) that lets you set the output bit format/depth with the command `swaymsg output '*' render_bit_depth 5`.