### PR TITLE
[feature] Parse slurp's default geometry output format

### DIFF
--- a/docs/wayshot.1.scd
+++ b/docs/wayshot.1.scd
@@ -40,9 +40,11 @@ Wayshot - Screenshot tool for compositors implementing zwlr_screencopy_v1 such a
 *-o*, *--output*
 	Choose a particular display (wl_output) to screenshot.
 
-*-s*, *--slurp*
+*-s*, *--slurp* <GEOMETRY>
 	Choose a portion of your display to screenshot using the slurp program.
-	https://github.com/emersion/slurp
+	https://github.com/emersion/slurp . Valid arguments have the form
+	"%x %y %w %h" or "%x,%y %wx%h", where for example "%w" is an integer giving
+	the width of the region.
 
 *--stdout*
 	Emit image data to stdout. The following flag is helpful to pipe image data


### PR DESCRIPTION
This makes it possible to capture a region using `wayshot -s "$(slurp)"`, which requires less work to type than `wayshot -s "$(slurp  -f '%x %y %w %h')" `. Both the current ("%X %Y %W %H") and slurp default ("%X,%Y %Wx%H")  geometry formats can be used.