### PR TITLE
chore: when make a big image,loop skip first one

### DIFF
--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -379,8 +379,8 @@ impl WayshotConnection {
                 images.push(image);
             }
             composited_image = images[0].clone();
-            for image in images {
-                overlay(&mut composited_image, &image, 0, 0);
+            for image in images.iter().skip(1) {
+                overlay(&mut composited_image, image, 0, 0);
             }
         }
 


### PR DESCRIPTION
this maybe can make screen overlay a bit faster