### PR TITLE
Performance Tuning

### DIFF
--- a/libwayshot/src/image_util.rs
+++ b/libwayshot/src/image_util.rs
@@ -1,46 +1,35 @@
-use image::{GenericImageView, ImageBuffer, Pixel};
+use image::RgbaImage;
 use wayland_client::protocol::wl_output::Transform;
 
-pub(crate) fn rotate_image_buffer<T: GenericImageView>(
-    image: &T,
+pub(crate) fn rotate_image_buffer(
+    image: RgbaImage,
     transform: Transform,
     width: u32,
     height: u32,
-) -> ImageBuffer<T::Pixel, Vec<<T::Pixel as Pixel>::Subpixel>>
-where
-    T::Pixel: 'static,
-    <T::Pixel as Pixel>::Subpixel: 'static,
-{
-    let final_buffer: ImageBuffer<
-        <T as GenericImageView>::Pixel,
-        Vec<<<T as GenericImageView>::Pixel as Pixel>::Subpixel>,
-    > = match transform {
-        Transform::_90 => image::imageops::rotate90(image),
-        Transform::_180 => image::imageops::rotate180(image),
-        Transform::_270 => image::imageops::rotate270(image),
-        Transform::Flipped => image::imageops::flip_horizontal(image),
+) -> RgbaImage {
+    let final_buffer = match transform {
+        Transform::_90 => image::imageops::rotate90(&image),
+        Transform::_180 => image::imageops::rotate180(&image),
+        Transform::_270 => image::imageops::rotate270(&image),
+        Transform::Flipped => image::imageops::flip_horizontal(&image),
         Transform::Flipped90 => {
-            let flipped_buffer = image::imageops::flip_horizontal(image);
+            let flipped_buffer = image::imageops::flip_horizontal(&image);
             image::imageops::rotate90(&flipped_buffer)
         }
         Transform::Flipped180 => {
-            let flipped_buffer = image::imageops::flip_horizontal(image);
+            let flipped_buffer = image::imageops::flip_horizontal(&image);
             image::imageops::rotate180(&flipped_buffer)
         }
         Transform::Flipped270 => {
-            let flipped_buffer = image::imageops::flip_horizontal(image);
+            let flipped_buffer = image::imageops::flip_horizontal(&image);
             image::imageops::rotate270(&flipped_buffer)
         }
-        _ => {
-            let final_buffer = image::imageops::resize(
-                image,
-                width,
-                height,
-                image::imageops::FilterType::Gaussian,
-            );
-            return final_buffer;
-        }
+        _ => image,
     };
+
+    if final_buffer.dimensions() == (width, height) {
+        return final_buffer;
+    }
 
     image::imageops::resize(
         &final_buffer,

--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use image::{imageops::overlay, DynamicImage, RgbaImage};
+use image::{imageops::overlay, RgbaImage};
 use memmap2::MmapMut;
 use wayland_client::{
     globals::{registry_queue_init, GlobalList},
@@ -414,9 +414,9 @@ impl WayshotConnection {
             let (width, height) = frame_copy.1.unwrap();
             let frame_copy = &frame_copy.0[0];
 
-            let image: DynamicImage = frame_copy.try_into()?;
+            let image = frame_copy.try_into()?;
             composited_image = image_util::rotate_image_buffer(
-                &image,
+                image,
                 frame_copy.transform,
                 width as u32,
                 height as u32,
@@ -426,9 +426,9 @@ impl WayshotConnection {
             let (frame_copy, region) = frame_copy;
             let (width, height) = region.unwrap();
             for frame_copy in frame_copy {
-                let image: DynamicImage = (&frame_copy).try_into()?;
+                let image = (&frame_copy).try_into()?;
                 let image = image_util::rotate_image_buffer(
-                    &image,
+                    image,
                     frame_copy.transform,
                     width as u32,
                     height as u32,
@@ -456,8 +456,7 @@ impl WayshotConnection {
             output_info.transform,
             None,
         )?;
-        let dynamic_image: DynamicImage = (&frame_copy).try_into()?;
-        Ok(dynamic_image.into_rgba8())
+        Ok((&frame_copy).try_into()?)
     }
 
     /// Take a screenshot from all of the specified outputs.

--- a/libwayshot/src/screencopy.rs
+++ b/libwayshot/src/screencopy.rs
@@ -4,7 +4,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use image::{ColorType, DynamicImage, ImageBuffer, Pixel};
+use image::{ColorType, ImageBuffer, Pixel, RgbaImage};
 use memmap2::MmapMut;
 use nix::{
     fcntl,
@@ -46,19 +46,14 @@ pub struct FrameCopy {
     pub transform: wl_output::Transform,
 }
 
-impl TryFrom<&FrameCopy> for DynamicImage {
+impl TryFrom<&FrameCopy> for RgbaImage {
     type Error = Error;
 
     fn try_from(value: &FrameCopy) -> Result<Self> {
         Ok(match value.frame_color_type {
-            ColorType::Rgb8 => DynamicImage::ImageRgb8(create_image_buffer(
-                &value.frame_format,
-                &value.frame_mmap,
-            )?),
-            ColorType::Rgba8 => DynamicImage::ImageRgba8(create_image_buffer(
-                &value.frame_format,
-                &value.frame_mmap,
-            )?),
+            ColorType::Rgb8 | ColorType::Rgba8 => {
+                create_image_buffer(&value.frame_format, &value.frame_mmap)?.into()
+            }
             _ => return Err(Error::InvalidColor),
         })
     }

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -22,7 +22,8 @@ where
         .with_prompt("Choose Screen")
         .default(0)
         .items(ouputs)
-        .interact() else {
+        .interact()
+    else {
         return None;
     };
     Some(selection)


### PR DESCRIPTION
I was working on the freezing functionality and along the way I'll use this PR to include some performance improvements.

# 1. Unneeded resized

`image_util::rotate_image_buffer` did 1-2 unneeded resizes. Remove the first one if the transform is a normal (or default) and remove the second if the requested size is the same as the original size.

<details>
<summary>Flamegraph before</summary>

![image](https://github.com/waycrate/wayshot/assets/1593486/0f2ac43d-8e63-45a8-bd6a-78318cd8bb86)
</details>

<details>
<summary>Flamegraph after</summary>

![image](https://github.com/waycrate/wayshot/assets/1593486/d85d285c-18da-448f-ad07-cadfc6838c94)
</details>



I noticed a run in release mode going from ~0.24s to ~0.13s. I could use `hyperfine` for a better comparison, but I think the flamegraph speaks for itself.