### PR TITLE
feat: add support for BGR888 image format

### DIFF
--- a/libwayshot/src/convert.rs
+++ b/libwayshot/src/convert.rs
@@ -15,6 +15,9 @@ struct ConvertNone {}
 #[derive(Default)]
 struct ConvertRGB8 {}
 
+#[derive(Default)]
+struct ConvertBGR888 {}
+
 const SHIFT10BITS_1: u32 = 20;
 const SHIFT10BITS_2: u32 = 10;
 
@@ -27,6 +30,7 @@ pub fn create_converter(format: wl_shm::Format) -> Option<Box<dyn Convert>> {
         wl_shm::Format::Xbgr2101010 | wl_shm::Format::Abgr2101010 => {
             Some(Box::<ConvertBGR10>::default())
         }
+        wl_shm::Format::Bgr888 => Some(Box::<ConvertBGR888>::default()),
         _ => None,
     }
 }
@@ -67,5 +71,11 @@ impl Convert for ConvertBGR10 {
             chunk[3] = 255;
         }
         ColorType::Rgba8
+    }
+}
+
+impl Convert for ConvertBGR888 {
+    fn convert_inplace(&self, _data: &mut [u8]) -> ColorType {
+        ColorType::Rgb8
     }
 }

--- a/libwayshot/src/image_util.rs
+++ b/libwayshot/src/image_util.rs
@@ -1,4 +1,4 @@
-use image::{DynamicImage, RgbaImage};
+use image::{DynamicImage, GenericImageView};
 use wayland_client::protocol::wl_output::Transform;
 
 pub(crate) fn rotate_image_buffer(
@@ -6,35 +6,36 @@ pub(crate) fn rotate_image_buffer(
     transform: Transform,
     width: u32,
     height: u32,
-) -> RgbaImage {
-    let final_buffer = match transform {
-        Transform::_90 => image::imageops::rotate90(&image),
-        Transform::_180 => image::imageops::rotate180(&image),
-        Transform::_270 => image::imageops::rotate270(&image),
-        Transform::Flipped => image::imageops::flip_horizontal(&image),
+) -> DynamicImage {
+    let final_image = match transform {
+        Transform::_90 => image::imageops::rotate90(&image).into(),
+        Transform::_180 => image::imageops::rotate180(&image).into(),
+        Transform::_270 => image::imageops::rotate270(&image).into(),
+        Transform::Flipped => image::imageops::flip_horizontal(&image).into(),
         Transform::Flipped90 => {
             let flipped_buffer = image::imageops::flip_horizontal(&image);
-            image::imageops::rotate90(&flipped_buffer)
+            image::imageops::rotate90(&flipped_buffer).into()
         }
         Transform::Flipped180 => {
             let flipped_buffer = image::imageops::flip_horizontal(&image);
-            image::imageops::rotate180(&flipped_buffer)
+            image::imageops::rotate180(&flipped_buffer).into()
         }
         Transform::Flipped270 => {
             let flipped_buffer = image::imageops::flip_horizontal(&image);
-            image::imageops::rotate270(&flipped_buffer)
+            image::imageops::rotate270(&flipped_buffer).into()
         }
-        _ => image.into_rgba8(),
+        _ => image,
     };
 
-    if final_buffer.dimensions() == (width, height) {
-        return final_buffer;
+    if final_image.dimensions() == (width, height) {
+        return final_image;
     }
 
     image::imageops::resize(
-        &final_buffer,
+        &final_image,
         width,
         height,
         image::imageops::FilterType::Gaussian,
     )
+    .into()
 }

--- a/libwayshot/src/image_util.rs
+++ b/libwayshot/src/image_util.rs
@@ -1,8 +1,8 @@
-use image::RgbaImage;
+use image::{DynamicImage, RgbaImage};
 use wayland_client::protocol::wl_output::Transform;
 
 pub(crate) fn rotate_image_buffer(
-    image: RgbaImage,
+    image: DynamicImage,
     transform: Transform,
     width: u32,
     height: u32,
@@ -24,7 +24,7 @@ pub(crate) fn rotate_image_buffer(
             let flipped_buffer = image::imageops::flip_horizontal(&image);
             image::imageops::rotate270(&flipped_buffer)
         }
-        _ => image,
+        _ => image.into_rgba8(),
     };
 
     if final_buffer.dimensions() == (width, height) {

--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -19,7 +19,7 @@ use std::{
     thread,
 };
 
-use image::{imageops::overlay, DynamicImage, RgbaImage};
+use image::{imageops::overlay, DynamicImage};
 use memmap2::MmapMut;
 use wayland_client::{
     globals::{registry_queue_init, GlobalList},
@@ -444,7 +444,7 @@ impl WayshotConnection {
         &self,
         capture_region: CaptureRegion,
         cursor_overlay: bool,
-    ) -> Result<RgbaImage> {
+    ) -> Result<DynamicImage> {
         let (frame_copies, (width, height)) =
             self.create_frame_copy(capture_region, cursor_overlay)?;
 
@@ -500,15 +500,14 @@ impl WayshotConnection {
         &self,
         output_info: &OutputInfo,
         cursor_overlay: bool,
-    ) -> Result<RgbaImage> {
+    ) -> Result<DynamicImage> {
         let frame_copy = self.capture_output_frame(
             cursor_overlay,
             &output_info.wl_output,
             output_info.transform,
             None,
         )?;
-        let image = DynamicImage::try_from(frame_copy)?;
-        Ok(image.into_rgba8())
+        frame_copy.try_into()
     }
 
     /// Take a screenshot from all of the specified outputs.
@@ -516,7 +515,7 @@ impl WayshotConnection {
         &self,
         outputs: &Vec<OutputInfo>,
         cursor_overlay: bool,
-    ) -> Result<RgbaImage> {
+    ) -> Result<DynamicImage> {
         if outputs.is_empty() {
             return Err(Error::NoOutputs);
         }
@@ -551,7 +550,7 @@ impl WayshotConnection {
     }
 
     /// Take a screenshot from all accessible outputs.
-    pub fn screenshot_all(&self, cursor_overlay: bool) -> Result<RgbaImage> {
+    pub fn screenshot_all(&self, cursor_overlay: bool) -> Result<DynamicImage> {
         self.screenshot_outputs(self.get_all_outputs(), cursor_overlay)
     }
 }

--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -19,7 +19,7 @@ use std::{
     thread,
 };
 
-use image::{imageops::overlay, RgbaImage};
+use image::{imageops::overlay, DynamicImage, RgbaImage};
 use memmap2::MmapMut;
 use wayland_client::{
     globals::{registry_queue_init, GlobalList},
@@ -254,6 +254,7 @@ impl WayshotConnection {
                         | wl_shm::Format::Argb8888
                         | wl_shm::Format::Xrgb8888
                         | wl_shm::Format::Xbgr8888
+                        | wl_shm::Format::Bgr888
                 )
             })
             .copied();
@@ -506,7 +507,8 @@ impl WayshotConnection {
             output_info.transform,
             None,
         )?;
-        frame_copy.try_into()
+        let image = DynamicImage::try_from(frame_copy)?;
+        Ok(image.into_rgba8())
     }
 
     /// Take a screenshot from all of the specified outputs.

--- a/libwayshot/src/screencopy.rs
+++ b/libwayshot/src/screencopy.rs
@@ -4,7 +4,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use image::{ColorType, ImageBuffer, Pixel, RgbaImage};
+use image::{ColorType, DynamicImage, ImageBuffer, Pixel};
 use memmap2::MmapMut;
 use nix::{
     fcntl,
@@ -46,13 +46,16 @@ pub struct FrameCopy {
     pub transform: wl_output::Transform,
 }
 
-impl TryFrom<FrameCopy> for RgbaImage {
+impl TryFrom<FrameCopy> for DynamicImage {
     type Error = Error;
 
     fn try_from(value: FrameCopy) -> Result<Self> {
         Ok(match value.frame_color_type {
-            ColorType::Rgb8 | ColorType::Rgba8 => {
-                create_image_buffer(&value.frame_format, &value.frame_mmap)?
+            ColorType::Rgb8 => {
+                Self::ImageRgb8(create_image_buffer(&value.frame_format, &value.frame_mmap)?)
+            }
+            ColorType::Rgba8 => {
+                Self::ImageRgba8(create_image_buffer(&value.frame_format, &value.frame_mmap)?)
             }
             _ => return Err(Error::InvalidColor),
         })


### PR DESCRIPTION
Hello,

I use the dev version of Sway with NVidia proprietary drivers and I'm unable to take a screenshot using Wayshot.

```
2024-01-08T16:56:40.302884Z ERROR libwayshot: No suitable frame format found
Error: NoSupportedBufferFormat
```

Turns out that with my setup, the frame format is BGR888, which is not supported yet. So here is a small PR that seems to make it work for me.

BGR888 is a 3-byte-per-pixel frame format with no transparency, unlike other formats used so far. So in `convert_inplace`, there is no room in the buffer to turn it into an RGBA image. As a workaround, I use a `DynamicImage` type in subsequent operations to handle both RGB and RGBA formats.

I'm aware this may not be the best solution, please let me know if there is anything I can do to improve this code :)