### PR TITLE
Fix: support correct saving for scaled displays

### DIFF
--- a/libwayshot/src/image_util.rs
+++ b/libwayshot/src/image_util.rs
@@ -1,21 +1,24 @@
 use image::{DynamicImage, GenericImageView};
 use wayland_client::protocol::wl_output::Transform;
 
+use crate::region::Size;
+
+#[tracing::instrument(skip(image))]
 pub(crate) fn rotate_image_buffer(
     image: DynamicImage,
     transform: Transform,
-    width: u32,
-    height: u32,
+    logical_size: Size,
+    max_scale: f64,
 ) -> DynamicImage {
     // TODO Better document whether width and height are before or after the transform.
     // Perhaps this should be part of a cleanup of the FrameCopy struct.
-    let (width, height) = match transform {
+    let (logical_width, logical_height) = match transform {
         Transform::_90 | Transform::_270 | Transform::Flipped90 | Transform::Flipped270 => {
-            (height, width)
+            (logical_size.height, logical_size.width)
         }
-        _ => (width, height),
+        _ => (logical_size.width, logical_size.height),
     };
-    let final_image = match transform {
+    let rotated_image = match transform {
         Transform::_90 => image::imageops::rotate90(&image).into(),
         Transform::_180 => image::imageops::rotate180(&image).into(),
         Transform::_270 => image::imageops::rotate270(&image).into(),
@@ -35,14 +38,22 @@ pub(crate) fn rotate_image_buffer(
         _ => image,
     };
 
-    if final_image.dimensions() == (width, height) {
-        return final_image;
+    let scale = rotated_image.width() as f64 / logical_width as f64;
+    // The amount of scaling left to perform.
+    let scaling_left = max_scale / scale;
+    if scaling_left <= 1.0 {
+        tracing::debug!("No scaling left to do");
+        return rotated_image;
     }
 
+    tracing::debug!("Scaling left to do: {scaling_left}");
+    let new_width = (rotated_image.width() as f64 * scaling_left).round() as u32;
+    let new_height = (rotated_image.height() as f64 * scaling_left).round() as u32;
+    tracing::debug!("Resizing image to {new_width}x{new_height}");
     image::imageops::resize(
-        &final_image,
-        width,
-        height,
+        &rotated_image,
+        new_width,
+        new_height,
         image::imageops::FilterType::Gaussian,
     )
     .into()

--- a/libwayshot/src/output.rs
+++ b/libwayshot/src/output.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use wayland_client::protocol::{wl_output, wl_output::WlOutput};
 
-use crate::region::Region;
+use crate::region::{LogicalRegion, Size};
 
 /// Represents an accessible wayland output.
 ///
@@ -13,8 +13,8 @@ pub struct OutputInfo {
     pub name: String,
     pub description: String,
     pub transform: wl_output::Transform,
-    pub scale: i32,
-    pub region: Region,
+    pub physical_size: Size,
+    pub logical_region: LogicalRegion,
 }
 
 impl Display for OutputInfo {
@@ -25,5 +25,11 @@ impl Display for OutputInfo {
             name = self.name,
             description = self.description
         )
+    }
+}
+
+impl OutputInfo {
+    pub(crate) fn scale(&self) -> f64 {
+        self.physical_size.height as f64 / self.logical_region.inner.size.height as f64
     }
 }

--- a/libwayshot/src/screencopy.rs
+++ b/libwayshot/src/screencopy.rs
@@ -79,7 +79,8 @@ pub struct FrameCopy {
     pub frame_mmap: MmapMut,
     pub transform: wl_output::Transform,
     /// Logical region with the transform already applied.
-    pub region: LogicalRegion,
+    pub logical_region: LogicalRegion,
+    pub physical_size: Size,
 }
 
 impl TryFrom<&FrameCopy> for DynamicImage {


### PR DESCRIPTION
In #78 it was discussed that master did not support scaled displays. The way screenshotting works is that screencopies are requested in logical regions (so after scaling, a pixel is not a real world pixel), but they're actually saved as "physical" regions (before scaling, aka the unit is 1 real world pixel). Some issues that I fixed were:
1. We created the final image as a "logical" size. So when someone took a screenshot of a 4K screen that was scaled 200%, the picture in memory would be 4K but we would create a 1080p size output file. A 4K output file would now be created.
2. Following the previous step, we need to convert the "logical" region to a "phyiscal" region, aka scale it as well.

But how and where do we scale? From all of the outputs, we take the maximum scale and make sure to scale all other outputs the same amount. This makes sure that our final image will lose the least amount of information. I'm having a hard time explaining this so I'll give some examples in hopes that it makes sense:

1. 1x 1080p + 1x 4K @ 100% -> neither will be resized.
2. 1x 1080p + 1x 4K @ 200% -> the 1080p one will be scaled 200%.
3. 1x 4K @ 100% + 1x 4K @ 200% -> the 4K @ 100% will be scaled 200%.

This seemed the most logical default scaling to me. We could technically make it configurable, though the way it's setup now is that it assumes it will never scale it down.

Still have to do some testing when attaching multiple monitors, but it _should_ work. ™ I am working on my desk setup so it might take me a while to have more than 1 monitor, I'd appreciate someone else testing it with 2 screens and different scaling.

Note: this PR does not fix the freeze overlaying. I actually removed it even because the changes wouldn't allow for it and it needs to be fixed in another PR.