### PR TITLE
Clipboard integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "bytecount"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+
+[[package]]
 name = "bytemuck"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +169,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +215,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fuzzy-matcher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +275,12 @@ checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "image"
@@ -255,6 +296,16 @@ dependencies = [
  "num-traits",
  "png",
  "qoi",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -336,6 +387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +412,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -366,6 +424,16 @@ dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -415,16 +483,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "os_pipe"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "petgraph"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -544,6 +638,17 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
@@ -583,7 +688,7 @@ checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -615,7 +720,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -651,6 +756,20 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91adfd0607cacf6e4babdb870e9bec4037c1c4b151cfd279ccefc5e0c7feaa6d"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "lazy_static",
+ "nom",
+ "once_cell",
+ "petgraph",
 ]
 
 [[package]]
@@ -761,6 +880,7 @@ dependencies = [
  "libwayshot",
  "tracing",
  "tracing-subscriber",
+ "wl-clipboard-rs",
 ]
 
 [[package]]
@@ -982,6 +1102,26 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57af79e973eadf08627115c73847392e6b766856ab8e3844a59245354b23d2fa"
+dependencies = [
+ "derive-new",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "os_pipe",
+ "tempfile",
+ "thiserror",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
 
 [[package]]
 name = "zeroize"

--- a/wayshot/Cargo.toml
+++ b/wayshot/Cargo.toml
@@ -30,6 +30,7 @@ image = { version = "0.24", default-features = false, features = [
 
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 
+wl-clipboard-rs = "0.8.0"
 [[bin]]
 name = "wayshot"
 path = "src/wayshot.rs"

--- a/wayshot/src/clap.rs
+++ b/wayshot/src/clap.rs
@@ -21,6 +21,7 @@ pub fn set_flags() -> Command {
             arg!(-f - -file <FILE_PATH>)
                 .required(false)
                 .conflicts_with("stdout")
+                .conflicts_with("clipboard")
                 .action(ArgAction::Set)
                 .help("Mention a custom file path"),
         )
@@ -34,8 +35,17 @@ pub fn set_flags() -> Command {
             arg!(--stdout)
                 .required(false)
                 .conflicts_with("file")
+                .conflicts_with("clipboard")
                 .action(ArgAction::SetTrue)
                 .help("Output the image data to standard out"),
+        )
+        .arg(
+            arg!(-p - -clipboard)
+                .required(false)
+                .conflicts_with("file")
+                .conflicts_with("stdout")
+                .action(ArgAction::SetTrue)
+                .help("Output the image data to clipboard"),
         )
         .arg(
             arg!(-e --extension <FILE_EXTENSION>)

--- a/wayshot/src/utils.rs
+++ b/wayshot/src/utils.rs
@@ -40,6 +40,12 @@ pub fn parse_geometry(g: &str) -> Option<CaptureRegion> {
     })
 }
 
+/// Supported locations to save the screenshot to.
+pub enum SaveLocation {
+    File(String),
+    StdOut,
+}
+
 /// Supported image encoding formats.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum EncodingFormat {

--- a/wayshot/src/utils.rs
+++ b/wayshot/src/utils.rs
@@ -44,6 +44,7 @@ pub fn parse_geometry(g: &str) -> Option<CaptureRegion> {
 pub enum SaveLocation {
     File(String),
     StdOut,
+    Clipboard,
 }
 
 /// Supported image encoding formats.


### PR DESCRIPTION
This PR attempts to implement native clipboard support for wayshot using wl-clipboard-rs as discussed in https://github.com/waycrate/wayshot/issues/48

First, I decided to refactor in a new Enum type `SaveLocation` for representing the where the screenshot goes now that it's no longer a boolean choice. I've used `-p` or `--clipboard` as the command line switch for the feature.

wl-clipboard-rs has been added as a dependency and the copying functionality seems to be working with a few caveats I wanted to discuss before proceeding further:
* wl-clipboard-rs only works with compositors using the wlr-data-control protocol, it doesn't work on GNOME's mutter for instance: https://github.com/YaLTeR/wl-clipboard-rs/issues/39
* Reading up on the protocol, it appears that a process can only offer data to be copied only for as long as it stays alive. This is mostly fine for GUI apps but problems arise when you want to copy something to the clipboard and exit as a terminal app. Basically with this PR wayshot will offer up the screenshot for a small moment and immediately exit.
- What this means in practice is that the clipboard functionality in this PR is unusable without a clipboard manager setup. If you have a clipboard manager listening, it will copy the screenshot into it's own memory the moment wayshot offers up the screenshot and the user can get their screenshot from there even after wayshot quits.
- The way to circumvent this is to keep the process alive. wl-clipboard-rs's version of wl-copy for instance does some unsafe shenanigans to fork itself, disconnect stdin/stdout and maintains the image in-memory till some other process overwrites the clipboard: https://github.com/YaLTeR/wl-clipboard-rs/blob/10b35fb2699a0ff65888b1220804bb0c44b65e0f/wl-clipboard-rs-tools/src/bin/wl-copy.rs#L160 I believe this is the same thing wl-copy does. We'll also have to do something similar to achieve parity with the wayshot --stdout | wl-copy method.