### PR TITLE
feat(clipboard): implement clipboard integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "bytecount"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+
+[[package]]
 name = "bytemuck"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,7 +138,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -176,6 +182,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +226,12 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -246,6 +269,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +285,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fuzzy-matcher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +298,12 @@ checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
@@ -291,6 +332,16 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "indexmap"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "jpeg-decoder"
@@ -371,6 +422,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +447,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -401,6 +459,16 @@ dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -450,16 +518,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "os_pipe"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "petgraph"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -579,6 +673,17 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
@@ -618,7 +723,7 @@ checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -650,7 +755,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -686,6 +791,20 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91adfd0607cacf6e4babdb870e9bec4037c1c4b151cfd279ccefc5e0c7feaa6d"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "lazy_static",
+ "nom",
+ "once_cell",
+ "petgraph",
 ]
 
 [[package]]
@@ -797,6 +916,7 @@ dependencies = [
  "libwayshot",
  "tracing",
  "tracing-subscriber",
+ "wl-clipboard-rs",
 ]
 
 [[package]]
@@ -1018,6 +1138,26 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57af79e973eadf08627115c73847392e6b766856ab8e3844a59245354b23d2fa"
+dependencies = [
+ "derive-new",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "os_pipe",
+ "tempfile",
+ "thiserror",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fork"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e74d3423998a57e9d906e49252fb79eb4a04d5cdfe188fb1b7ff9fc076a8ed"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fuzzy-matcher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +921,7 @@ dependencies = [
  "dialoguer",
  "eyre",
  "flate2",
+ "fork",
  "image",
  "libwayshot",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "clap"
 version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,15 +297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fork"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e74d3423998a57e9d906e49252fb79eb4a04d5cdfe188fb1b7ff9fc076a8ed"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "fuzzy-matcher"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,9 +363,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
@@ -467,6 +464,18 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -921,9 +930,9 @@ dependencies = [
  "dialoguer",
  "eyre",
  "flate2",
- "fork",
  "image",
  "libwayshot",
+ "nix 0.28.0",
  "tracing",
  "tracing-subscriber",
  "wl-clipboard-rs",

--- a/wayshot/Cargo.toml
+++ b/wayshot/Cargo.toml
@@ -33,6 +33,8 @@ image = { version = "0.24", default-features = false, features = [
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 eyre = "0.6.8"
 
+wl-clipboard-rs = "0.8.0"
+
 [[bin]]
 name = "wayshot"
 path = "src/wayshot.rs"

--- a/wayshot/Cargo.toml
+++ b/wayshot/Cargo.toml
@@ -34,6 +34,7 @@ dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 eyre = "0.6.8"
 
 wl-clipboard-rs = "0.8.0"
+fork = "0.1.23"
 
 [[bin]]
 name = "wayshot"

--- a/wayshot/Cargo.toml
+++ b/wayshot/Cargo.toml
@@ -34,7 +34,7 @@ dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 eyre = "0.6.8"
 
 wl-clipboard-rs = "0.8.0"
-fork = "0.1.23"
+nix = { version = "0.28.0", features = ["process"] }
 
 [[bin]]
 name = "wayshot"

--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -11,10 +11,14 @@ use clap::builder::TypedValueParser;
 #[derive(Parser)]
 #[command(version, about)]
 pub struct Cli {
-    /// Where to save the screenshot, "-" for stdout. Defaults to "$UNIX_TIMESTAMP-wayshot.$EXTENSION".
+    /// Where to save the screenshot, "-" for stdout. Defaults to "$UNIX_TIMESTAMP-wayshot.$EXTENSION" unless --clipboard is present.
     #[arg(value_name = "OUTPUT")]
     pub file: Option<PathBuf>,
-
+    
+    /// Copy image to clipboard along with [OUTPUT] or stdout
+    #[arg(long)]
+    pub clipboard: bool,
+    
     /// Log level to be used for printing to stderr
     #[arg(long, default_value = "info", value_parser = clap::builder::PossibleValuesParser::new(["trace", "debug", "info", "warn", "error"]).map(|s| -> tracing::Level{ s.parse().wrap_err_with(|| format!("Failed to parse log level: {}", s)).unwrap()}))]
     pub log_level: tracing::Level,

--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -15,7 +15,7 @@ pub struct Cli {
     #[arg(value_name = "OUTPUT")]
     pub file: Option<PathBuf>,
 
-    /// Copy image to clipboard along with [OUTPUT] or stdout
+    /// Copy image to clipboard along with [OUTPUT] or stdout. wayshot persists in the background to offer the image till the clipboard is overwritten.
     #[arg(long)]
     pub clipboard: bool,
 

--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -14,11 +14,11 @@ pub struct Cli {
     /// Where to save the screenshot, "-" for stdout. Defaults to "$UNIX_TIMESTAMP-wayshot.$EXTENSION" unless --clipboard is present.
     #[arg(value_name = "OUTPUT")]
     pub file: Option<PathBuf>,
-    
+
     /// Copy image to clipboard along with [OUTPUT] or stdout
     #[arg(long)]
     pub clipboard: bool,
-    
+
     /// Log level to be used for printing to stderr
     #[arg(long, default_value = "info", value_parser = clap::builder::PossibleValuesParser::new(["trace", "debug", "info", "warn", "error"]).map(|s| -> tracing::Level{ s.parse().wrap_err_with(|| format!("Failed to parse log level: {}", s)).unwrap()}))]
     pub log_level: tracing::Level,

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -143,7 +143,7 @@ fn main() -> Result<()> {
                     return Ok(());
                 }
                 Ok(ForkResult::Child) => {
-                    opts.foreground(true); //Offer the image till somthing else is available on the clipboard
+                    opts.foreground(true); // Offer the image till something else is available on the clipboard
                     opts.copy(
                         Source::Bytes(buffer.into_inner().into()),
                         MimeType::Autodetect,

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -139,7 +139,7 @@ fn main() -> Result<()> {
             match unsafe { fork() } {
                 // Having the image persistently available on the clipboard requires a wayshot process to be alive.
                 // Fork the process with a child detached from the main process and have the parent exit
-                Ok(ForkResult::Parent{..}) => {
+                Ok(ForkResult::Parent { .. }) => {
                     return Ok(());
                 }
                 Ok(ForkResult::Child) => {

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -15,7 +15,7 @@ use utils::EncodingFormat;
 
 use wl_clipboard_rs::copy::{MimeType, Options, Source};
 
-use fork::{fork, Fork};
+use nix::unistd::{fork, ForkResult};
 
 fn select_ouput<T>(ouputs: &[T]) -> Option<usize>
 where
@@ -136,13 +136,13 @@ fn main() -> Result<()> {
         }
         if cli.clipboard {
             let mut opts = Options::new();
-            match fork() {
+            match unsafe { fork() } {
                 // Having the image persistently available on the clipboard requires a wayshot process to be alive.
                 // Fork the process with a child detached from the main process and have the parent exit
-                Ok(Fork::Parent(_)) => {
+                Ok(ForkResult::Parent{..}) => {
                     return Ok(());
                 }
-                Ok(Fork::Child) => {
+                Ok(ForkResult::Child) => {
                     opts.foreground(true); //Offer the image till somthing else is available on the clipboard
                     opts.copy(
                         Source::Bytes(buffer.into_inner().into()),

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -150,7 +150,8 @@ fn main() -> Result<()> {
                     )?;
                 }
                 Err(e) => {
-                    println!("Fork failed with error: {e}, couldn't offer image on the clipboard persistently. Use a clipboard manager.");
+                    tracing::warn!("Fork failed with error: {e}, couldn't offer image on the clipboard persistently.
+                     Use a clipboard manager to record screenshot.");
                     opts.copy(
                         Source::Bytes(buffer.into_inner().into()),
                         MimeType::Autodetect,


### PR DESCRIPTION
This PR adds a --clipboard flag and implements functionality to make the screenshot available on the clipboard using wl-clipboard-rs. All the caveats described in https://github.com/waycrate/wayshot/pull/89#issue-2151702439 are still applicable:
> - Reading up on the protocol, it appears that a process can only offer data to be copied only for as long as it stays alive. This is mostly fine for GUI apps but problems arise when you want to copy something to the clipboard and exit as a terminal app. Basically with this PR wayshot will offer up the screenshot for a small moment and immediately exit.
> - What this means in practice is that the clipboard functionality in this PR is unusable without a clipboard manager setup. If you have a clipboard manager listening, it will copy the screenshot into it's own memory the moment wayshot offers up the screenshot and the user can get their screenshot from there even after wayshot quits.
> - The way to circumvent this is to keep the process alive. wl-clipboard-rs's version of wl-copy for instance does some unsafe shenanigans to fork itself, disconnect stdin/stdout and maintains the image in-memory till some other process overwrites the clipboard: https://github.com/YaLTeR/wl-clipboard-rs/blob/10b35fb2699a0ff65888b1220804bb0c44b65e0f/wl-clipboard-rs-tools/src/bin/wl-copy.rs#L160 I believe this is the same thing wl-copy does. We'll also have to do something similar to achieve parity with the wayshot --stdout | wl-copy method.
