### PR TITLE
accounting for directories in file path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,10 @@ name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+dependencies = [
+ "jobserver",
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -338,6 +342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +404,7 @@ dependencies = [
  "num-traits",
  "png",
  "qoi",
+ "webp",
 ]
 
 [[package]]
@@ -410,6 +421,15 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -461,6 +481,16 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-wlr",
+]
+
+[[package]]
+name = "libwebp-sys"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829b6b604f31ed6d2bccbac841fe0788de93dbd87e4eb1ba2c4adfe8c012a838"
+dependencies = [
+ "cc",
+ "glob",
 ]
 
 [[package]]
@@ -993,6 +1023,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wl-clipboard-rs",
+]
+
+[[package]]
+name = "webp"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb5d8e7814e92297b0e1c773ce43d290bef6c17452dafd9fc49e5edb5beba71"
+dependencies = [
+ "libwebp-sys",
 ]
 
 [[package]]

--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -11,12 +11,16 @@ use clap::builder::TypedValueParser;
 #[derive(Parser)]
 #[command(version, about)]
 pub struct Cli {
-    ///Provide a custom file path ( encoding format is inferred from the file extension ). If path provided is directory then the output image is saved to provided path with default naming scheme. Default path is ./ , `-` indicates writing to terminal (stdout).
-    #[arg(value_name = "OUTPUT")]
+    /// Custom output path can be of the following types:
+    ///     1. Directory (Default naming scheme is used for the image output).
+    ///     2. Path (Encoding is automatically inferred from the extension).
+    ///     3. `-` (Indicates writing to terminal [stdout]).
+    #[arg(value_name = "OUTPUT", verbatim_doc_comment)]
     pub file: Option<PathBuf>,
 
-    /// Copy image to clipboard along with [OUTPUT] or stdout. Wayshot persists in the background to offer the image till the clipboard is overwritten.
-    #[arg(long)]
+    /// Copy image to clipboard along with [OUTPUT] or stdout.
+    /// Wayshot persists in the background to offer the image till the clipboard is overwritten.
+    #[arg(long, verbatim_doc_comment)]
     pub clipboard: bool,
 
     /// Log level to be used for printing to stderr
@@ -33,7 +37,7 @@ pub struct Cli {
 
     /// Set image encoder, by default uses the file extension from the OUTPUT
     /// positional argument. Otherwise defaults to png.
-    #[arg(long, visible_aliases = ["extension", "format", "output-format"], value_name = "FILE_EXTENSION")]
+    #[arg(long, verbatim_doc_comment, visible_aliases = ["extension", "format", "output-format"], value_name = "FILE_EXTENSION")]
     pub encoding: Option<EncodingFormat>,
 
     /// List all valid outputs

--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -11,7 +11,7 @@ use clap::builder::TypedValueParser;
 #[derive(Parser)]
 #[command(version, about)]
 pub struct Cli {
-    /// Where to save the screenshot, "-" for stdout. Defaults to "$UNIX_TIMESTAMP-wayshot.$EXTENSION".
+    ///Provide a custom file path ( encoding format is inferred from the file extension ). If path provided is directory then the output image is saved to provided path with default naming scheme. Default path is ./ , `-` indicates writing to terminal (stdout).
     #[arg(value_name = "OUTPUT")]
     pub file: Option<PathBuf>,
 

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -59,10 +59,8 @@ fn main() -> Result<()> {
             } else {
                 if pathbuf.is_dir() {
                     pathbuf.push(utils::get_default_file_name(requested_encoding));
-                    Some(pathbuf)
-                } else {
-                    Some(pathbuf)
-                }
+                } 
+                Some(pathbuf)
             }
         }
         None => Some(utils::get_default_file_name(requested_encoding)),

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -59,7 +59,7 @@ fn main() -> Result<()> {
             } else {
                 if pathbuf.is_dir() {
                     pathbuf.push(utils::get_default_file_name(requested_encoding));
-                } 
+                }
                 Some(pathbuf)
             }
         }

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -53,11 +53,16 @@ fn main() -> Result<()> {
     }
 
     let file = match cli.file {
-        Some(pathbuf) => {
+        Some(mut pathbuf) => {
             if pathbuf.to_string_lossy() == "-" {
                 None
             } else {
-                Some(pathbuf)
+                if pathbuf.is_dir() {
+                    pathbuf.push(utils::get_default_file_name(requested_encoding));
+                    Some(pathbuf)
+                } else {
+                    Some(pathbuf)
+                }
             }
         }
         None => Some(utils::get_default_file_name(requested_encoding)),

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -56,20 +56,6 @@ fn main() -> Result<()> {
         }
     }
 
-    let file = match cli.file {
-        Some(mut pathbuf) => {
-            if pathbuf.to_string_lossy() == "-" {
-                None
-            } else {
-                if pathbuf.is_dir() {
-                    pathbuf.push(utils::get_default_file_name(requested_encoding));
-                }
-                Some(pathbuf)
-            }
-        }
-        None => Some(utils::get_default_file_name(requested_encoding)),
-    };
-
     let wayshot_conn = WayshotConnection::new()?;
 
     if cli.list_outputs {
@@ -120,11 +106,14 @@ fn main() -> Result<()> {
 
     let mut stdout_print = false;
     let file = match cli.file {
-        Some(pathbuf) => {
+        Some(mut pathbuf) => {
             if pathbuf.to_string_lossy() == "-" {
                 stdout_print = true;
                 None
             } else {
+                if pathbuf.is_dir() {
+                    pathbuf.push(utils::get_default_file_name(requested_encoding));
+                }
                 Some(pathbuf)
             }
         }


### PR DESCRIPTION
Currently Wayshot save screenshots in the current working directory. However this is not ideal as some users like to save screenshots in a particular directory(For example $HOME/Pictures/screenshots).
This PR introduces a `--folder` flag which allows users to select save directory for their screenshots. 