### PR TITLE
feat(clipboard): fix interaction with freeze and select feature: Issue #109

### DIFF
--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -413,7 +413,13 @@ impl WayshotConnection {
         Ok(frame_copies)
     }
 
-    fn overlay_frames(&self, frames: &[(FrameCopy, FrameGuard, OutputInfo)]) -> Result<()> {
+    /// Create a layer shell surface for each output,
+    /// render the screen captures on them and use the callback to select a region from them
+    fn overlay_frames_and_select_region(
+        &self,
+        frames: &[(FrameCopy, FrameGuard, OutputInfo)],
+        callback: Box<dyn Fn() -> Result<LogicalRegion, Error>>,
+    ) -> Result<(LogicalRegion)> {
         let mut state = LayerShellState {
             configured_outputs: HashSet::new(),
         };
@@ -491,7 +497,10 @@ impl WayshotConnection {
                 Ok(())
             })?;
         }
-        Ok(())
+        let region = callback()?;
+        layer_shell.destroy();
+        event_queue.blocking_dispatch(&mut state)?;
+        Ok(region)
     }
 
     /// Take a screenshot from the specified region.
@@ -547,7 +556,7 @@ impl WayshotConnection {
             RegionCapturer::Outputs(outputs) => outputs.as_slice().try_into()?,
             RegionCapturer::Region(region) => region,
             RegionCapturer::Freeze(callback) => {
-                self.overlay_frames(&frames).and_then(|_| callback())?
+                self.overlay_frames_and_select_region(&frames, callback)?
             }
         };
 

--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -419,7 +419,7 @@ impl WayshotConnection {
         &self,
         frames: &[(FrameCopy, FrameGuard, OutputInfo)],
         callback: Box<dyn Fn() -> Result<LogicalRegion, Error>>,
-    ) -> Result<(LogicalRegion)> {
+    ) -> Result<LogicalRegion> {
         let mut state = LayerShellState {
             configured_outputs: HashSet::new(),
         };
@@ -497,10 +497,10 @@ impl WayshotConnection {
                 Ok(())
             })?;
         }
-        let region = callback()?;
+        let callback_result = callback();
         layer_shell.destroy();
         event_queue.blocking_dispatch(&mut state)?;
-        Ok(region)
+        callback_result
     }
 
     /// Take a screenshot from the specified region.


### PR DESCRIPTION
Modifies the overlay creation function to destroy the shell surfaces after use. Not much familiar with layer shell so input from @AndreasBackx would be appreciated on if this is all that is required. I have moved the slurp callback activation into that function too because it needs to be called before the surface is destroyed and destroying the surface needs context only present within this function.