### PR TITLE
fix(layer-shell-scaling): frozen buffers must scale to output scaling.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "image",
  "memmap2",
  "nix 0.27.1",
+ "tempfile",
  "thiserror",
  "tracing",
  "wayland-client",

--- a/libwayshot/Cargo.toml
+++ b/libwayshot/Cargo.toml
@@ -18,3 +18,4 @@ thiserror = "1"
 wayland-client = "0.31.1"
 wayland-protocols = { version = "0.31.0", features = ["client", "unstable"] }
 wayland-protocols-wlr = { version = "0.2.0", features = ["client"] }
+tempfile = "3.10.1"

--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -28,8 +28,8 @@ pub struct Cli {
     pub log_level: tracing::Level,
 
     /// Arguments to call slurp with for selecting a region
-    #[arg(short, long, value_name = "SLURP_ARGS")]
-    pub slurp: Option<String>,
+    #[arg(short, long)]
+    pub slurp: bool,
 
     /// Enable cursor in screenshots
     #[arg(short, long)]

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -66,15 +66,11 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let image_buffer = if let Some(slurp_region) = cli.slurp {
-        let slurp_region = slurp_region.clone();
+    let image_buffer = if cli.slurp {
         wayshot_conn.screenshot_freeze(
             Box::new(move || {
                 || -> Result<LogicalRegion> {
-                    let slurp_output = Command::new("slurp")
-                        .args(slurp_region.split(' '))
-                        .output()?
-                        .stdout;
+                    let slurp_output = Command::new("slurp").arg("-d").output()?.stdout;
 
                     utils::parse_geometry(&String::from_utf8(slurp_output)?)
                 }()


### PR DESCRIPTION
I have read the portocol of fractional, the protocal just accept a scale value to client and let client to adjust the scale. so finally the way to scale is done by client. So the scale should be done by ourself