### PR TITLE
Destroy layer shell surfaces instead of layer shell for freeze-feat

### DIFF
--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -452,6 +452,8 @@ impl WayshotConnection {
             }
         };
 
+        let mut layer_shell_surfaces = Vec::new();
+
         for (frame_copy, frame_guard, output_info) in frames {
             tracing::span!(
                 tracing::Level::DEBUG,
@@ -491,15 +493,21 @@ impl WayshotConnection {
 
                 debug!("Committing surface with attached buffer.");
                 surface.commit();
-
+                layer_shell_surfaces.push(layer_surface);
                 event_queue.blocking_dispatch(&mut state)?;
 
                 Ok(())
             })?;
         }
+
         let callback_result = callback();
-        layer_shell.destroy();
+
+        debug!("Destroying layer shell surfaces.");
+        for layer_shell_surface in layer_shell_surfaces.into_iter() {
+            layer_shell_surface.destroy();
+        }
         event_queue.blocking_dispatch(&mut state)?;
+
         callback_result
     }
 

--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -505,7 +505,7 @@ impl WayshotConnection {
         debug!("Unmapping and destroying layer shell surfaces.");
         for (surface, layer_shell_surface) in layer_shell_surfaces.iter() {
             surface.attach(None, 0, 0);
-            surface.commit(); //unmap surface by commiting a null buffer
+            surface.commit(); //unmap surface by committing a null buffer
             layer_shell_surface.destroy();
         }
         event_queue.roundtrip(&mut state)?;

--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -452,7 +452,7 @@ impl WayshotConnection {
             }
         };
 
-        let mut layer_shell_surfaces = Vec::new();
+        let mut layer_shell_surfaces = Vec::with_capacity(frames.len());
 
         for (frame_copy, frame_guard, output_info) in frames {
             tracing::span!(


### PR DESCRIPTION
Attempts to solve the freeze feature crashing sporadically  as described in https://github.com/waycrate/wayshot/issues/109#issuecomment-2051750240
https://github.com/waycrate/wayshot/issues/109#issuecomment-2052105490 :

> Alright, I have a patch that solves this. The existing code destroys the layer_shell object instead of the layer_surface objects, destroying only layer_surface objects seems to solve the issue but destroying both in that order doesn't. It isn't clear to me why this is the case but I'll create a PR for you to test.

@Gigas002 can you test this fix?