### PR TITLE
Replace nix with rustix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ version = "0.3.2-dev"
 dependencies = [
  "image",
  "memmap2",
- "nix 0.27.1",
+ "rustix",
  "thiserror",
  "tracing",
  "wayland-client",
@@ -534,17 +534,6 @@ checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
  "simd-adler32",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.5.0",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -1019,7 +1008,7 @@ dependencies = [
  "flate2",
  "image",
  "libwayshot",
- "nix 0.28.0",
+ "rustix",
  "tracing",
  "tracing-subscriber",
  "wl-clipboard-rs",
@@ -1140,7 +1129,7 @@ dependencies = [
  "derive-new",
  "libc",
  "log",
- "nix 0.28.0",
+ "nix",
  "os_pipe",
  "tempfile",
  "thiserror",

--- a/libwayshot/Cargo.toml
+++ b/libwayshot/Cargo.toml
@@ -12,7 +12,7 @@ edition.workspace = true
 tracing.workspace = true
 image = { version = "0.24", default-features = false }
 memmap2 = "0.9.0"
-nix = { version = "0.27.1", features = ["fs", "mman"] }
+rustix = { version = "0.38", features = ["fs", "shm"] }
 thiserror = "1"
 
 wayland-client = "0.31.1"

--- a/wayshot/Cargo.toml
+++ b/wayshot/Cargo.toml
@@ -36,7 +36,7 @@ eyre = "0.6.8"
 chrono = "0.4.35"
 
 wl-clipboard-rs = "0.8.0"
-nix = { version = "0.28.0", features = ["process"] }
+rustix = { version = "0.38", features = ["process", "runtime"] }
 
 [[bin]]
 name = "wayshot"

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -15,7 +15,7 @@ use utils::EncodingFormat;
 
 use wl_clipboard_rs::copy::{MimeType, Options, Source};
 
-use nix::unistd::{fork, ForkResult};
+use rustix::runtime::{fork, Fork};
 
 fn select_ouput<T>(ouputs: &[T]) -> Option<usize>
 where
@@ -158,10 +158,10 @@ fn clipboard_daemonize(buffer: Cursor<Vec<u8>>) -> Result<()> {
     match unsafe { fork() } {
         // Having the image persistently available on the clipboard requires a wayshot process to be alive.
         // Fork the process with a child detached from the main process and have the parent exit
-        Ok(ForkResult::Parent { .. }) => {
+        Ok(Fork::Parent(_)) => {
             return Ok(());
         }
-        Ok(ForkResult::Child) => {
+        Ok(Fork::Child(_)) => {
             opts.foreground(true); // Offer the image till something else is available on the clipboard
             opts.copy(
                 Source::Bytes(buffer.into_inner().into()),


### PR DESCRIPTION
As title says, this PR proposes replacement of `nix` crate with [rustix](https://github.com/bytecodealliance/rustix).
Currently, the only package dependent on `nix` is a `wl-clipboard-rs`, and it's moving from `nix` to `rustix` as well in upcoming update to match the `wayland-rs`: https://github.com/YaLTeR/wl-clipboard-rs/commit/e81562a06b4c4879bd14524c86c866654a17e4b2
This change simplifies dependency tree for a bit and the migration is pretty straightforward. If there's any downsides I'm not aware of these.