### PR TITLE
Add missing conversion from_str to webp enum

### DIFF
--- a/wayshot/src/utils.rs
+++ b/wayshot/src/utils.rs
@@ -128,6 +128,7 @@ impl FromStr for EncodingFormat {
             "png" => Self::Png,
             "ppm" => Self::Ppm,
             "qoi" => Self::Qoi,
+            "webp" => Self::Webp,
             _ => bail!("unsupported extension '{s}'"),
         })
     }


### PR DESCRIPTION
Missed in the PR #98 I proposed with this feature, sorry.
Was implemented as part of #104, but since there was a request to separate stuff from it here's this PR