### PR TITLE
Update image crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,14 +108,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
-dependencies = [
- "jobserver",
- "libc",
-]
 
 [[package]]
 name = "cfg-if"
@@ -182,12 +184,6 @@ name = "clap_lex"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
-
-[[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -342,12 +338,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,18 +383,28 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.9"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+checksum = "fd54d660e773627692c524beaad361aca785a4f9f5730ce91f42aabe5bce3d11"
 dependencies = [
  "bytemuck",
  "byteorder",
- "color_quant",
- "jpeg-decoder",
+ "image-webp",
  "num-traits",
  "png",
  "qoi",
- "webp",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d730b085583c4d789dfd07fdcf185be59501666a90c97c40162b37e4fdad272d"
+dependencies = [
+ "byteorder-lite",
+ "thiserror",
 ]
 
 [[package]]
@@ -422,21 +422,6 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
-
-[[package]]
-name = "jobserver"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
@@ -481,16 +466,6 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-wlr",
-]
-
-[[package]]
-name = "libwebp-sys"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829b6b604f31ed6d2bccbac841fe0788de93dbd87e4eb1ba2c4adfe8c012a838"
-dependencies = [
- "cc",
- "glob",
 ]
 
 [[package]]
@@ -1015,15 +990,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webp"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb5d8e7814e92297b0e1c773ce43d290bef6c17452dafd9fc49e5edb5beba71"
-dependencies = [
- "libwebp-sys",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,3 +1111,18 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec866b44a2a1fd6133d363f073ca1b179f438f99e7e5bfb1e33f7181facfe448"
+dependencies = [
+ "zune-core",
+]

--- a/libwayshot/Cargo.toml
+++ b/libwayshot/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 
 [dependencies]
 tracing.workspace = true
-image = { version = "0.24", default-features = false }
+image = { version = "0.25", default-features = false }
 memmap2 = "0.9.0"
 rustix = { version = "0.38", features = ["fs", "shm"] }
 thiserror = "1"

--- a/wayshot/Cargo.toml
+++ b/wayshot/Cargo.toml
@@ -23,12 +23,12 @@ libwayshot.workspace = true
 clap = { version = "4.4.18", features = ["derive"] }
 tracing-subscriber = "0.3.17"
 
-image = { version = "0.24", default-features = false, features = [
+image = { version = "0.25", default-features = false, features = [
 	"jpeg",
 	"png",
 	"pnm",
 	"qoi",
-	"webp-encoder",
+	"webp",
 ] }
 
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }

--- a/wayshot/src/utils.rs
+++ b/wayshot/src/utils.rs
@@ -68,14 +68,14 @@ impl Default for EncodingFormat {
     }
 }
 
-impl From<EncodingFormat> for image::ImageOutputFormat {
+impl From<EncodingFormat> for image::ImageFormat {
     fn from(format: EncodingFormat) -> Self {
         match format {
-            EncodingFormat::Jpg => image::ImageFormat::Jpeg.into(),
-            EncodingFormat::Png => image::ImageFormat::Png.into(),
-            EncodingFormat::Ppm => image::ImageFormat::Pnm.into(),
-            EncodingFormat::Qoi => image::ImageFormat::Qoi.into(),
-            EncodingFormat::Webp => image::ImageFormat::WebP.into(),
+            EncodingFormat::Jpg => image::ImageFormat::Jpeg,
+            EncodingFormat::Png => image::ImageFormat::Png,
+            EncodingFormat::Ppm => image::ImageFormat::Pnm,
+            EncodingFormat::Qoi => image::ImageFormat::Qoi,
+            EncodingFormat::Webp => image::ImageFormat::WebP,
         }
     }
 }

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -131,7 +131,7 @@ fn main() -> Result<()> {
         image_buffer.save(file)?;
     } else if stdout_print {
         let mut buffer = Cursor::new(Vec::new());
-        image_buffer.write_to(&mut buffer, requested_encoding)?;
+        image_buffer.write_to(&mut buffer, requested_encoding.into())?;
         let stdout = stdout();
         let mut writer = BufWriter::new(stdout.lock());
         writer.write_all(buffer.get_ref())?;
@@ -143,7 +143,7 @@ fn main() -> Result<()> {
             Some(buf) => buf,
             None => {
                 let mut buffer = Cursor::new(Vec::new());
-                image_buffer.write_to(&mut buffer, requested_encoding)?;
+                image_buffer.write_to(&mut buffer, requested_encoding.into())?;
                 buffer
             }
         })?;


### PR DESCRIPTION
This PR updates the `image` crate to version [0.25](https://github.com/image-rs/image/blob/main/CHANGES.md).
This version changes the `webp` encoder from binding library to a pure rust native `webp` encoder and also changes `jpeg`-decoders in favor of more performant `zune-jpeg` package.
BTW, maybe it's a good time to introduce the `dependabot` alerts for updating repo dependencies?