### PR TITLE
ci: add dependabot scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Rust projects
+  - package-ecosystem: "cargo"
+    directories:
+      - "/"
+      - "/wayshot"
+      - "/libwayshot"
+      - "/libwayshot/examples/waymirror-egl"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   # Rust projects
   - package-ecosystem: "cargo"
@@ -17,4 +17,4 @@ updates:
       - "/libwayshot"
       - "/libwayshot/examples/waymirror-egl"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
Now that ci build is fixed, I think is a good time to introduce automated dependabot versions scans