### PR TITLE
feat(cli): add optional --delay argument for screenshot countdown

### DIFF
--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -51,4 +51,8 @@ pub struct Cli {
     /// Present a fuzzy selector for output/display selection
     #[arg(long, alias = "chooseoutput", conflicts_with_all = ["slurp", "output"])]
     pub choose_output: bool,
+
+    ///Number of seconds to wait before taking the screenshot
+    #[arg(long, short, default_value = "0", value_name = "SECONDS")]
+    pub delay: u64,
 }

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{stdout, BufWriter, Cursor, Write},
+    io::{self, stdout, BufWriter, Cursor, Write},
     process::Command,
 };
 
@@ -38,6 +38,13 @@ fn main() -> Result<()> {
         .with_max_level(cli.log_level)
         .with_writer(std::io::stderr)
         .init();
+
+    if cli.delay > 0 {
+        print!("Waiting {} seconds before capture...", cli.delay);
+        io::stdout().flush().ok();
+        std::thread::sleep(std::time::Duration::from_secs(cli.delay));
+        println!("Done!");
+    }
 
     let input_encoding = cli
         .file


### PR DESCRIPTION
Allows specifying a delay before capturing screenshots. Helpful for hovering menus or tooltips.