### PR TITLE
chore: minor improvements in libwayshot lib.rs

### DIFF
--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -526,17 +526,14 @@ impl WayshotConnection {
                         | wl_shm::Format::Bgr888
                 )
             })
-            .copied();
+            .copied()
+            // Check if frame format exists.
+            .ok_or_else(|| {
+                tracing::error!("No suitable frame format found");
+                Error::NoSupportedBufferFormat
+            })?;
         tracing::trace!("Selected frame buffer format: {:#?}", frame_format);
 
-        // Check if frame format exists.
-        let frame_format = match frame_format {
-            Some(format) => format,
-            None => {
-                tracing::error!("No suitable frame format found");
-                return Err(Error::NoSupportedBufferFormat);
-            }
-        };
         Ok((state, event_queue, frame, frame_format))
     }
 

--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -813,7 +813,7 @@ impl WayshotConnection {
             Ok(x) => x,
             Err(e) => {
                 tracing::error!(
-                    "Failed to create compositor Does your compositor implement WlCompositor?"
+                    "Failed to create compositor. Does your compositor implement WlCompositor?"
                 );
                 tracing::error!("err: {e}");
                 return Err(Error::ProtocolNotFound(
@@ -1062,7 +1062,8 @@ impl WayshotConnection {
     ) -> Result<DynamicImage> {
         self.screenshot_region_capturer(RegionCapturer::Freeze(callback), cursor_overlay)
     }
-    /// shot one ouput
+
+    /// Take a screenshot from one output
     pub fn screenshot_single_output(
         &self,
         output_info: &OutputInfo,


### PR DESCRIPTION
- use `ok_or_else()` function to check if frame format exists in `capture_output_frame_get_state_shm()` function
- fixed "failed to create compositor" tracing error message
- fixed typo in `screenshot_single_output()` function's comment