### PR TITLE
chore: improvements in waymirror-egl example

### DIFF
--- a/libwayshot/examples/waymirror-egl/src/main.rs
+++ b/libwayshot/examples/waymirror-egl/src/main.rs
@@ -53,7 +53,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         event_queue.dispatch_pending(&mut state)?;
         state.draw();
         state
-            .egl
+            .egl_instance
             .swap_buffers(state.egl_display.unwrap(), state.egl_surface.unwrap())?;
 
         tracing::trace!("eglSwapBuffers called");

--- a/libwayshot/examples/waymirror-egl/src/main.rs
+++ b/libwayshot/examples/waymirror-egl/src/main.rs
@@ -49,6 +49,9 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     state.wl_surface.clone().unwrap().commit();
 
     state.init_egl()?;
+
+    println!("Starting the example EGL-enabled wayshot dmabuf demo app, press <ESC> to quit.");
+
     while state.running {
         event_queue.dispatch_pending(&mut state)?;
         state.draw();

--- a/libwayshot/examples/waymirror.rs
+++ b/libwayshot/examples/waymirror.rs
@@ -100,7 +100,7 @@ impl State {
 
         let xdg_surface = wm_base.get_xdg_surface(base_surface, qh, ());
         let toplevel = xdg_surface.get_toplevel(qh, ());
-        toplevel.set_title("DMABuf+wlr-screencpy example!".into());
+        toplevel.set_title("DMABuf+wlr-screencopy example!".into());
 
         base_surface.commit();
 


### PR DESCRIPTION
### Changes made:
- Rename the `egl` variable to `egl_instance` to avoid confusion in waymirror-egl state
- Fix a typo in `waymirror.rs`
- Add a keybind `<ESC>` to terminate a waymirror-egl instance