### PR TITLE
Add CLI options to set default config values

### DIFF
--- a/docs/wayshot.1.scd
+++ b/docs/wayshot.1.scd
@@ -84,7 +84,20 @@ Wayshot - Screenshot tool for compositors implementing zwlr_screencopy_v1 such a
 
 	Example: *wayshot --config config.toml*
 
+*--set-default-path <SET_DEFAULT_PATH>*
+	Sets the default screenshot saving path in the config file.
+	
+	Example: *wayshot --set-default-path "/home/user/screenshots"*
 
+*--set-cursor <SET_CURSOR>*
+	Sets the default cursor visibility when taking screenshots.
+	
+	Example: *wayshot --set-cursor true*
+	
+*--set-clipboard <SET_CLIPBOARD>*
+	Sets the default behavior for copying screenshots to the clipboard.
+	
+	Example: *wayshot --set-clipboard true*
 # SEE ALSO
 	- wayshot(5)
 	- wayshot(7)

--- a/wayshot/Cargo.toml
+++ b/wayshot/Cargo.toml
@@ -40,7 +40,7 @@ wl-clipboard-rs = "0.9.2"
 rustix = { version = "1.0", features = ["process", "runtime"] }
 
 shellexpand = "3.1.0"
-toml = { version = "0.8.20", default-features = false, features = ["parse"] }
+toml = { version = "0.8.20", default-features = false, features = ["parse","display"] }
 serde = { version = "1.0.219", features = ["derive"] }
 dirs = "6.0.0"
 libwaysip = "0.3.0"

--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -75,4 +75,13 @@ pub struct Cli {
     ///     3. `None` -- if the config isn't found, the `Config::default()` will be used
     #[arg(long, verbatim_doc_comment)]
     pub config: Option<PathBuf>,
+
+    #[arg(long,verbatim_doc_comment, help = "Sets the default screenshot saving path in the config file")]
+    pub set_default_path: Option<PathBuf>,
+
+    #[arg(long, verbatim_doc_comment, help = "Set default cursor visibility (true/false)")]
+    pub set_cursor: Option<bool>,
+
+    #[arg(long,verbatim_doc_comment,help = "Set default clipboard behavior (true/false)")]
+    pub set_clipboard: Option<bool>,
 }

--- a/wayshot/src/config.rs
+++ b/wayshot/src/config.rs
@@ -32,6 +32,18 @@ impl Config {
             .map(|path| path.join("wayshot").join("config.toml"))
             .unwrap_or_default()
     }
+    pub fn save(&self, path: &PathBuf) -> Result<(), eyre::Error> {
+        let toml = toml::to_string(self)?;  
+        // Create parent directories if needed
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| eyre::eyre!("Failed to create config directory: {}", e))?;
+        }
+        
+        std::fs::write(path, toml)
+            .map_err(|e| eyre::eyre!("Failed to write config file: {}", e))?;
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -37,6 +37,19 @@ where
 fn main() -> Result<()> {
     let cli = cli::Cli::parse();
     let config_path = cli.config.unwrap_or(Config::get_default_path());
+
+    if cli.set_default_path.is_some() || cli.set_cursor.is_some() || cli.set_clipboard.is_some() {
+
+        utils::update_config(
+            &config_path,
+            cli.set_default_path,
+            cli.set_cursor,
+            cli.set_clipboard,
+        )?;
+        return Ok(());
+    }
+
+    
     let config = Config::load(&config_path).unwrap_or_default();
     let base = config.base.unwrap_or_default();
     let file = config.file.unwrap_or_default();


### PR DESCRIPTION
This PR adds new CLI flags to set default values directly in the config file, removes the need for manual editing of config.toml.

New options added:
`--set-default-path <PATH>`: Sets the default screenshot save path.

`--set-cursor <true|false>`: Sets default cursor visibility in screenshots.

`--set-clipboard <true|false>`: Sets default behavior for copying screenshots to the clipboard.

also should I add other set flags too?