### PR TITLE
chore: update Nix flake

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,7 @@ indent_size = 4
 [*.{rs}]
 indent_style = space
 indent_size = 4
+
+[*.nix]
+indent_style = space
+indent_size = 2

--- a/flake.lock
+++ b/flake.lock
@@ -1,41 +1,39 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
+    "flake-compat": {
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,49 @@
 {
-  description = "Development environment for wayshot";
+  description = "wayshot devel and build";
 
-  inputs = {
-    flake-utils.url = "github:numtide/flake-utils";
-  };
+  # Unstable required until Rust 1.85 (2024 edition) is on stable
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs =
-    {
-      flake-utils,
-      ...
-    }:
-    flake-utils.lib.eachDefaultSystem (system:
-    {
-      devShells.default = import ./shell.nix;
-    });
+  # shell.nix compatibility
+  inputs.flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      # System types to support.
+      targetSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs targetSystems;
+    in {
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            strictDeps = true;
+            RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+            nativeBuildInputs = with pkgs; [
+              cargo
+              rustc
+              pkg-config
+
+              rustfmt
+              clippy
+              rust-analyzer
+
+              scdoc
+            ];
+
+            buildInputs = with pkgs; [
+              wayland
+              libGL # libegl
+              glib
+              pango
+              libgbm
+            ];
+          };
+        }
+      );
+    };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,45 +1,13 @@
-# shell.nix
-
-with (import <nixpkgs> { });
-
-let
-  libPath =
-    with pkgs;
-    lib.makeLibraryPath [
-      libgbm
-      wayland
-      # You can load external libraries that you need in your rust project here
-    ];
-  moz_overlay = import (builtins.fetchTarball "https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz");
-  # Here I have used pkgs-mozilla overlays for my use case however you can use any other method you prefer!!
-
-  nixpkgs = import <nixpkgs> {
-    overlays = [
-      moz_overlay
-    ];
-  };
-
-in
-mkShell {
-  name = "moz_overlay_shell";
-  buildInputs = [
-    libGL.dev
-    libgbm
-	pkg-config
-    wayland.dev
-    nixpkgs.latest.rustChannels.nightly.rust
-  ];
-  LD_LIBRARY_PATH = libPath;
-  RUST_BACKTRACE = 1;
-  shellHook = ''
-    # Set the RUST_SRC_PATH environment variable to the rust-src location if required
-    export RUST_SRC_PATH="${nixpkgs.latest.rustChannels.nightly.rust-src}/lib/rustlib/src/rust/library"
-  '';
-  BINDGEN_EXTRA_CLANG_ARGS =
-    (builtins.map (a: ''-I"${a}/include"'') [
-      # Add include paths for other libraries here
-    ])
-    ++ [
-      # Special directories
-    ];
-}
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+      nodeName = lock.nodes.root.inputs.flake-compat;
+    in
+    fetchTarball {
+      url = lock.nodes.${nodeName}.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+      sha256 = lock.nodes.${nodeName}.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
FYI: you can test these with
```nix
rm -rf target
cargo vendor
# create .cargo/config.toml as `cargo vendor` tells you to
# This tests the build in a pretty isolated environment
nix develop -i --command cargo b
# The bins will fail without the WAYLAND_DISPLAY environment  variable, run them outside of the isolated environment
./target/debug/wayshot
./target/debug/waymirror-egl
```
Should I make a Nix package for wayshot? I'm guessing no since it's already in Nixpkgs and there's really no good reason to use a newer version