### PR TITLE
fix: prevent EmbeddedRegion false positive on bordering viewport

### DIFF
--- a/libwayshot/src/region.rs
+++ b/libwayshot/src/region.rs
@@ -104,6 +104,9 @@ impl EmbeddedRegion {
             relative_to.inner.size.width as i32,
         );
         let width = if let Ok(width) = (x2 - x1).try_into() {
+            if width < 1 {
+                return None;
+            };
             width
         } else {
             return None;
@@ -115,6 +118,9 @@ impl EmbeddedRegion {
             relative_to.inner.size.height as i32,
         );
         let height = if let Ok(height) = (y2 - y1).try_into() {
+            if height < 1 {
+                return None;
+            };
             height
         } else {
             return None;


### PR DESCRIPTION
Trying to capture e.g. a (0, 123)1920x456 region when there is a second output at (1920, 0) causes the library to request a zero width area of the second output from the compositor which at least on wlroots causes an error.