### PR TITLE
Add utility functions to support screencasting in xdg-desktop-portal-luminous

### DIFF
--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -567,12 +567,7 @@ impl WayshotConnection {
         Ok((state, event_queue, frame))
     }
 
-    // This API is exposed to provide users with access to window manager (WM)
-    // information. For instance, enabling Vulkan in wlroots alters the display
-    // format. Consequently, using PipeWire to capture streams without knowing
-    // the current format can lead to color distortion. This function attempts
-    // a trial screenshot to determine the screen's properties.
-    pub fn capture_output_frame_get_state_shm(
+    fn capture_output_frame_get_state_shm(
         &self,
         cursor_overlay: i32,
         output: &WlOutput,

--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -199,13 +199,29 @@ impl WayshotConnection {
         Ok(())
     }
 
+    /// Query which `wl_shm::Format` the compositor supports for this output by performing a trial screenshot through wlr-screencopy protocol.
+    /// # Parameters
+    /// - `output`: Reference to the `WlOutput` to inspect.
+    /// # Returns
+    /// - A vector of [`FrameFormat`] if screen capture succeeds.
+    /// - [`Error::ProtocolNotFound`] if wlr-screencopy protocol is not found.
     pub fn get_available_frame_formats(&self, output: &WlOutput) -> Result<Vec<FrameFormat>> {
         let (state, _event_queue, _frame) = self.capture_output_frame_get_state(0, output, None)?;
         Ok(state.formats)
     }
 
-    /// Get a FrameCopy instance with screenshot pixel data for any wl_output object.
-    /// Data will be written to fd if format is available for screenshot.
+    /// Captures a screenshot into a shared memory buffer using a specified format, if available, and writes pixel data in the provided file descriptor.
+    /// This function uses wlr-screencopy protocol to capture pixel data from a `WlOutput`.
+    /// # Parameters
+    /// - `cursor_overlay`: A boolean flag indicating whether the cursor should be included in the capture.
+    /// - `output`: Reference to the `WlOutput` from which the frame is to be captured.
+    /// - `fd`: file descriptor where the capture buffer will be written.
+    /// - `frame_format`: `wl_shm::Format` to use for screen capture.
+    /// - `capture_region`: Optional region specifying a sub-area of the output to capture. If `None`, the entire output is captured.
+    /// # Returns
+    /// - A [`FrameGuard`] instance that holds the screen capture result, if screen capture is successful and frame_format is supported.
+    /// - [`Error::FramecopyFailed`] if screen capture fails.
+    /// - [`Error::NoSupportedBufferFormat`] if frame_format is not supported for the given output.
     pub fn capture_output_frame_shm_fd_with_format<T: AsFd>(
         &self,
         cursor_overlay: i32,


### PR DESCRIPTION
This PR adds two utility functions, designed to be used by [`xdg-desktop-portal-luminous`](https://github.com/waycrate/xdg-desktop-portal-luminous):

- `get_available_frame_formats`:  returns a vector of valid formats for a given `WlOutput`. The original idea was to pick a random `WlOutput` from the connection, performing a 1-pixel screenshot to obtain the valid formats using `wlr-screencopy` protocol, and saving them in a `LazyCell`. I preferred to capture the entire screen from a given `WlOutput` passed as parameter instead, to return a vector of `FrameFormat` which contain additional information such as the size and the stride of the buffer. This makes the function more general purpose, allowing it to be used in multiple contexts. For example, right now only 4-bytes pixel formats are supported; if other pixel formats need to be supported in the future, this information could be useful to properly set PipeWire streams' parameters.
- `capture_output_frame_shm_fd_with_format`: same as `capture_output_frame_shm_fd`, but enforces a format to perform the screen capture. Needed since the PipeWire server communicates a preferred video format among the available ones, that must be enforced when capturing video frames.

Additionally, some refactoring was done to avoid code repetitions and `pub` visibility modifier was removed from `capture_output_frame_get_state_shm`, as it was added in an attempt to tackle the issues that `get_available_frame_formats` solves.
