### PR TITLE
chore: maybe it can be a bug or rust of wayland-rs

### DIFF
--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -727,6 +727,12 @@ impl WayshotConnection {
             .bind::<ExtOutputImageCaptureSourceManagerV1, _, _>(&qh, 1..=1, ())
             .expect("Should have");
         let source = output_management.create_source(output, &qh, ());
+        // NOTE: when cursor_overlay is 1, as a variable ,the options will also be PaintCursors,
+        // but the cursor won't shown
+        // But if we do the things below. the cursor_overlay is also 1, but it is a new one. Then
+        // the cursor will be shown as normal.
+        // I think maybe it should be a bug of rust. I do not know..
+        // let cursor_overlay: i32 = 1;
         let options = Options::from_bits(cursor_overlay.try_into().unwrap_or(0))
             .unwrap_or(Options::PaintCursors);
         let session = manager.create_session(&source, options, &qh, ());


### PR DESCRIPTION
https://github.com/waycrate/xdg-desktop-portal-luminous/blob/master/src/pipewirethread.rs#L159-L170

relate logic is here.

## First try
I always found that the the cursor cannot be shown when using the ext-image-copy. I though maybe I cast the i32 to u32, and then I always get 0. but after I print the value of options, it always be PaintCursors!!

## Second try
Then I think maybe the PaintCursors is a fake one, or maybe something wrong with from_bits, then I try to fixed the options to Options::from_bits(1), and the cursor shown!

## Final try
Then I cannot believe my mind. I try something that impossible. I create another i32 value

```rust
let cursor_overlay: i32 = 1;
```

and just print the origin cursor_overlay, and even add a assert_eq, to check if the input one is the same as the new one. 

*They are the same*

but with the new value, cursor_overlay(1), `the cursor shown`. Then I deleted the line of the new value, the cursor gone, with the input param of `cursor_overlay(1)` and `Options::PaintCursors`

This is a magic of these days.. I do not know who to blame 

## Etc

I also tried
```rust
 let session = if cursor_overlay == 1 {
       manager.create_session(&source, Options::PaintCursors, &qh, ());
  } else {
        manager.create_session(&source, Options::empty(), &qh, ());
 };
```
It also did not work
