### PR TITLE
Handle gbm errors instead of panicking

### DIFF
--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -178,7 +178,7 @@ impl WayshotConnection {
             globals.bind(&evq.handle(), 4..=ZwpLinuxDmabufV1::interface().version, ())?;
         let gpu = dispatch::Card::open(device_path);
         // init a GBM device
-        let gbm = GBMDevice::new(gpu).unwrap();
+        let gbm = GBMDevice::new(gpu)?;
         let image_copy_support = check_ext_image_copy_protocols(&globals, &conn).is_ok();
         let toplevel_capture_support = check_toplevel_protocols(&globals, &conn).is_ok();
         let mut initial_state = Self {


### PR DESCRIPTION
### Fix potential panic in GBM device initialization

This PR prevents a potential panic in `libwayshot` when GBM device initialization fails.
The code previously used `unwrap()`, which would crash the program on error.

- Replaced `GBMDevice::new(gpu).unwrap()` with `GBMDevice::new(gpu)?`
- Allows the error to be returned to the caller instead of panicking.
