### PR TITLE
fix: remove example from wayshot compilation process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["wayshot", "libwayshot", "libwayshot/examples/waymirror-egl"]
+members = ["wayshot", "libwayshot"]
 
 [workspace.package]
 authors = ["Shinyzenith <https://aakash.is-a.dev>"]


### PR DESCRIPTION
Right now, building wayshot can fail, due to `waymirror-egl` requiring more dependencies, than `wayshot` needs. This affects users on distros, that use `git` packages, specifically and build from source.

I don't think that we must force users to install more dependencies to build the example they won't ever use/notice, so it looks like a good enough idea to remove it from build process.

The example can still be compiled by `cd`ing into it's directory, so interested parties can still do it. 
If the example app is meant to be usable though, it makes more sense to publish it separately, like `waysip` has it's own repo.