### PR TITLE
feature: add code coverage CI action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Install wayland dependencies
       run: |
-        pacman -Syu --noconfirm egl-wayland egl-gbm wayland base-devel mesa pango cairo libjxl
+        pacman -Syu --noconfirm git egl-wayland egl-gbm wayland base-devel mesa pango cairo libjxl
 
     - name: Install cargo-llvm-cov
       run: |


### PR DESCRIPTION
As discussed (in #94 comments), I tried adding the code coverage Ci action.
This requires adding the repository to https://codecov.io/ and adding the `CODECOV_TOKEN` secret to repo, otherwise codecov upload will fail (the action itself will still work as of now, not failing the whole CI)