### PR TITLE
Fix scaling detection for portrait displays

### DIFF
--- a/libwayshot/src/image_util.rs
+++ b/libwayshot/src/image_util.rs
@@ -7,17 +7,10 @@ use crate::region::Size;
 pub(crate) fn rotate_image_buffer(
     image: DynamicImage,
     transform: Transform,
+    // Includes transform already.
     logical_size: Size,
     max_scale: f64,
 ) -> DynamicImage {
-    // TODO Better document whether width and height are before or after the transform.
-    // Perhaps this should be part of a cleanup of the FrameCopy struct.
-    let (logical_width, _logical_height) = match transform {
-        Transform::_90 | Transform::_270 | Transform::Flipped90 | Transform::Flipped270 => {
-            (logical_size.height, logical_size.width)
-        }
-        _ => (logical_size.width, logical_size.height),
-    };
     let rotated_image = match transform {
         Transform::_90 => image::imageops::rotate90(&image).into(),
         Transform::_180 => image::imageops::rotate180(&image).into(),
@@ -38,15 +31,20 @@ pub(crate) fn rotate_image_buffer(
         _ => image,
     };
 
-    let scale = rotated_image.width() as f64 / logical_width as f64;
+    let rotated_width = rotated_image.width();
+    tracing::trace!(
+        "Rotated width: {rotated_width}, logical width: {}",
+        logical_size.width
+    );
+    let scale = rotated_width as f64 / logical_size.width as f64;
     // The amount of scaling left to perform.
     let scaling_left = max_scale / scale;
+    tracing::debug!("Current scale: {scale}, scaling left (max/current): {scaling_left}");
     if scaling_left <= 1.0 {
         tracing::debug!("No scaling left to do");
         return rotated_image;
     }
 
-    tracing::debug!("Scaling left to do: {scaling_left}");
     let new_width = (rotated_image.width() as f64 * scaling_left).round() as u32;
     let new_height = (rotated_image.height() as f64 * scaling_left).round() as u32;
     tracing::debug!("Resizing image to {new_width}x{new_height}");


### PR DESCRIPTION
Fixed calculating the needed resize for portrait displays. The `Size` struct passed to `image_util::rotate_image_buffer` was at some moment changed to include the transformation already but wasn't changed there.

Tested using the following setup:
1. Left: 1.25 scale 4K portrait
2. Middle: 1.25 scale 4K landscape
3. Right: 1.25 scale and 4K portrait that was changed to 1.0 scale to see if it worked.


_JPG used below as PNGs were too big to upload here._

## With 1.0 scale on the right portrait

### Before

![wayshot-2025_12_27-13_05_04](https://github.com/user-attachments/assets/4c807085-42fb-4fe4-8d09-0e95bdb06b14)


### After
![wayshot-2025_12_27-13_05_52](https://github.com/user-attachments/assets/e8ab5d75-c7dc-4ef7-b24f-dd7c7e220f29)


## With 1.25 scale on the right portrait

### Before

![wayshot-2025_12_27-13_06_57](https://github.com/user-attachments/assets/fd47048c-cf26-4cb5-b3df-0838d0f4fe2e)


### After


![wayshot-2025_12_27-13_06_52](https://github.com/user-attachments/assets/d2bc20d5-cae0-45d8-b37b-bc804fe640ba)

