### PR TITLE
feat: add PNG optimization feature using oxipng

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 *.png
 *.ppm
 *.qoi
+*.jxl

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +492,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -550,6 +563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -797,6 +819,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +922,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +965,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -1149,6 +1209,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gobject-sys"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,6 +1348,7 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "rayon",
 ]
 
 [[package]]
@@ -1372,6 +1439,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
+name = "libdeflate-sys"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bd6304ebf75390d8a99b88bdf2a266f62647838140cb64af8e6702f6e3fddc"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libdeflater"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d4880e6d634d3d029d65fa016038e788cc728a17b782684726fb34ee140caf"
+dependencies = [
+ "libdeflate-sys",
+]
+
+[[package]]
 name = "libfuzzer-sys"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1484,7 @@ checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1727,6 +1813,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxipng"
+version = "9.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c613f0f566526a647c7473f6a8556dbce22c91b13485ee4b4ec7ab648e4973"
+dependencies = [
+ "bitvec",
+ "clap",
+ "crossbeam-channel",
+ "env_logger",
+ "filetime",
+ "glob",
+ "indexmap",
+ "libdeflater",
+ "log",
+ "rayon",
+ "rgb",
+ "rustc-hash",
+ "zopfli",
+]
+
+[[package]]
 name = "pango"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1993,6 +2100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,6 +2204,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,6 +2228,15 @@ name = "rgb"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -2304,6 +2435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2469,16 @@ dependencies = [
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+dependencies = [
+ "rustix 1.1.3",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2764,6 +2911,7 @@ dependencies = [
  "libwayshot",
  "libwaysip",
  "notify-rust",
+ "oxipng",
  "rustix 1.1.3",
  "serde",
  "shellexpand",
@@ -2940,7 +3088,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2958,14 +3115,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2993,10 +3167,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3005,10 +3191,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3017,10 +3215,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3029,10 +3239,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -3065,6 +3287,15 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-wlr",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]
@@ -3171,6 +3402,18 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Pick a hex color code, using ImageMagick:
 wayshot -g - | convert - -format '%[pixel:p{0,0}]' txt:-|grep -E "#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})" -o
 ```
 
+Screenshot with PNG optimization (smaller files, slower):
+
+```bash
+wayshot --optimize
+```
+
 # Installation
 
 ## AUR:

--- a/docs/wayshot.1.scd
+++ b/docs/wayshot.1.scd
@@ -88,6 +88,9 @@ Wayshot - Screenshot tool for compositors implementing zwlr_screencopy_v1 such a
 
 	Example: *wayshot --config config.toml*
 
+*--optimize*
+	Optimize PNG using oxipng. Reduces file size at the cost of ~5x slower encoding.
+
 
 # SEE ALSO
 	- wayshot(5)

--- a/docs/wayshot.5.scd
+++ b/docs/wayshot.5.scd
@@ -114,6 +114,11 @@ This section documents the *[file]* table of the configuration file
 
 	Default: _"png"_
 
+*optimize* = _true_ | _false_
+	Optimize PNG using oxipng. Slower (~5x) but smaller file sizes.
+	CLI option takes precedence: _wayshot --optimize_
+	Default: _false_
+
 ## ENCODING
 
 	Encoding-specific configuration options.

--- a/wayshot/Cargo.toml
+++ b/wayshot/Cargo.toml
@@ -49,6 +49,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 dirs = "6.0.0"
 libwaysip = "0.6.0"
 notify-rust = "4.11.7"
+oxipng = "9.1"
 
 [[bin]]
 name = "wayshot"

--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -96,6 +96,8 @@ pub struct Cli {
     #[arg(long, verbatim_doc_comment)]
     pub config: Option<PathBuf>,
 
+    /// Optimize PNG files using oxipng to reduce file size.
+    /// This process is slower but results in smaller images.
     #[arg(long)]
     pub optimize: bool,
 }

--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -96,8 +96,6 @@ pub struct Cli {
     #[arg(long, verbatim_doc_comment)]
     pub config: Option<PathBuf>,
 
-    /// Optimize PNG files using oxipng to reduce file size.
-    /// Only applies when saving to a PNG file.
     #[arg(long)]
     pub optimize: bool,
 }

--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -95,4 +95,9 @@ pub struct Cli {
     ///     3. `None` -- if the config isn't found, the `Config::default()` will be used
     #[arg(long, verbatim_doc_comment)]
     pub config: Option<PathBuf>,
+
+    /// Optimize PNG files using oxipng to reduce file size.
+    /// Only applies when saving to a PNG file.
+    #[arg(long)]
+    pub optimize: bool,
 }

--- a/wayshot/src/utils.rs
+++ b/wayshot/src/utils.rs
@@ -230,6 +230,16 @@ pub fn encode_to_png_bytes(
     Ok(buffer.into_inner())
 }
 
+pub fn encode_to_png_bytes_optimized(
+    image_buffer: &DynamicImage,
+    compression: CompressionType,
+    filter: FilterType,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let data = encode_to_png_bytes(image_buffer, compression, filter)?;
+    let optimized = oxipng::optimize_from_memory(&data, &oxipng::Options::default())?;
+    Ok(optimized)
+}
+
 pub fn encode_to_png(
     image_buffer: &DynamicImage,
     path: &PathBuf,
@@ -242,16 +252,15 @@ pub fn encode_to_png(
     Ok(())
 }
 
-pub fn optimize_png(data: Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let optimized = oxipng::optimize_from_memory(&data, &oxipng::Options::default())?;
-    Ok(optimized)
-}
-
-pub fn optimize_and_save_png(path: &PathBuf) -> Result<(), Box<dyn std::error::Error>> {
-    let data = std::fs::read(path)?;
-    let optimized = optimize_png(data)?;
+pub fn encode_to_png_optimized(
+    image_buffer: &DynamicImage,
+    path: &PathBuf,
+    compression: CompressionType,
+    filter: FilterType,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let data = encode_to_png_bytes_optimized(image_buffer, compression, filter)?;
     let mut file = File::create(path)?;
-    file.write_all(&optimized)?;
+    file.write_all(&data)?;
     Ok(())
 }
 

--- a/wayshot/src/utils.rs
+++ b/wayshot/src/utils.rs
@@ -242,6 +242,19 @@ pub fn encode_to_png(
     Ok(())
 }
 
+pub fn optimize_png(data: Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let optimized = oxipng::optimize_from_memory(&data, &oxipng::Options::default())?;
+    Ok(optimized)
+}
+
+pub fn optimize_and_save_png(path: &PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let data = std::fs::read(path)?;
+    let optimized = optimize_png(data)?;
+    let mut file = File::create(path)?;
+    file.write_all(&optimized)?;
+    Ok(())
+}
+
 const TIMEOUT: i32 = 5000;
 
 #[derive(Debug, Clone)]

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -273,17 +273,22 @@ fn main() -> Result<()> {
                         tracing::error!("Failed to encode to JXL: {}", e);
                     }
                 } else if encoding == EncodingFormat::Png {
-                    if let Err(e) = utils::encode_to_png(
+                    if cli.optimize {
+                        if let Err(e) = utils::encode_to_png_optimized(
+                            &image_buffer,
+                            &f,
+                            png_config.get_compression(),
+                            png_config.get_filter(),
+                        ) {
+                            tracing::error!("Failed to encode to PNG: {}", e);
+                        }
+                    } else if let Err(e) = utils::encode_to_png(
                         &image_buffer,
                         &f,
                         png_config.get_compression(),
                         png_config.get_filter(),
                     ) {
                         tracing::error!("Failed to encode to PNG: {}", e);
-                    } else if cli.optimize {
-                        if let Err(e) = utils::optimize_and_save_png(&f) {
-                            tracing::error!("Failed to optimize PNG: {}", e);
-                        }
                     }
                 } else {
                     image_buffer.save(f)?;
@@ -301,12 +306,21 @@ fn main() -> Result<()> {
                     .map_err(|e| eyre::eyre!("Failed to encode JXL: {}", e))?;
                     Cursor::new(data)
                 } else if encoding == EncodingFormat::Png {
-                    let data = utils::encode_to_png_bytes(
-                        &image_buffer,
-                        png_config.get_compression(),
-                        png_config.get_filter(),
-                    )
-                    .map_err(|e| eyre::eyre!("Failed to encode PNG: {}", e))?;
+                    let data = if cli.optimize {
+                        utils::encode_to_png_bytes_optimized(
+                            &image_buffer,
+                            png_config.get_compression(),
+                            png_config.get_filter(),
+                        )
+                        .map_err(|e| eyre::eyre!("Failed to encode PNG: {}", e))?
+                    } else {
+                        utils::encode_to_png_bytes(
+                            &image_buffer,
+                            png_config.get_compression(),
+                            png_config.get_filter(),
+                        )
+                        .map_err(|e| eyre::eyre!("Failed to encode PNG: {}", e))?
+                    };
                     Cursor::new(data)
                 } else {
                     let mut buffer = Cursor::new(Vec::new());
@@ -331,12 +345,21 @@ fn main() -> Result<()> {
                             .map_err(|e| eyre::eyre!("Failed to encode JXL: {}", e))?;
                             Cursor::new(data)
                         } else if encoding == EncodingFormat::Png {
-                            let data = utils::encode_to_png_bytes(
-                                &image_buffer,
-                                png_config.get_compression(),
-                                png_config.get_filter(),
-                            )
-                            .map_err(|e| eyre::eyre!("Failed to encode PNG: {}", e))?;
+                            let data = if cli.optimize {
+                                utils::encode_to_png_bytes_optimized(
+                                    &image_buffer,
+                                    png_config.get_compression(),
+                                    png_config.get_filter(),
+                                )
+                                .map_err(|e| eyre::eyre!("Failed to encode PNG: {}", e))?
+                            } else {
+                                utils::encode_to_png_bytes(
+                                    &image_buffer,
+                                    png_config.get_compression(),
+                                    png_config.get_filter(),
+                                )
+                                .map_err(|e| eyre::eyre!("Failed to encode PNG: {}", e))?
+                            };
                             Cursor::new(data)
                         } else {
                             let mut buffer = Cursor::new(Vec::new());

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -280,6 +280,10 @@ fn main() -> Result<()> {
                         png_config.get_filter(),
                     ) {
                         tracing::error!("Failed to encode to PNG: {}", e);
+                    } else if cli.optimize {
+                        if let Err(e) = utils::optimize_and_save_png(&f) {
+                            tracing::error!("Failed to optimize PNG: {}", e);
+                        }
                     }
                 } else {
                     image_buffer.save(f)?;


### PR DESCRIPTION
closes #95

ran some benchmarks on my VM **i7 14700K 6 Cores** (1680 x 1050) 

|  | Standard PNG | Optimized (`--optimize`) | JXL |
| :--- | :--- | :--- | :--- |
| **Time** | 0.10s | **0.55s** | 0.69s |
| **Memory** | ~35 MB | ~75 MB | **~254 MB** |
| **Size** | 202 KB | **39 KB** | 56 KB |

### why the flag?
while `oxipng` crushes the file size (202kb -> 39kb), the **~5.5x speed hit** makes it kinda unsuitable for a default. 

honestly tho it's a better alternative to JXL right now. in my testing JXL was actually slower (0.69s), ate a ton of ram (~254mb), and the file size was actually bigger (56kb) than the optimized png.