### PR TITLE
Adding --silent to cli

### DIFF
--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -95,4 +95,8 @@ pub struct Cli {
     ///     3. `None` -- if the config isn't found, the `Config::default()` will be used
     #[arg(long, verbatim_doc_comment)]
     pub config: Option<PathBuf>,
+
+    /// Silents notification after screenshot
+    #[arg(long)]
+    pub silent: bool,
 }

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -44,7 +44,7 @@ fn main() -> Result<()> {
     let encoding_config = config.encoding.unwrap_or_default();
     let jxl_config = encoding_config.jxl.unwrap_or_default();
     let png_config = encoding_config.png.unwrap_or_default();
-    let notifications_enabled = base.notifications.unwrap_or(true);
+    let notifications_enabled = !cli.silent && base.notifications.unwrap_or(true);
 
     let log_level = cli.log_level.unwrap_or(base.get_log_level());
     tracing_subscriber::fmt()


### PR DESCRIPTION
Addressing issue https://github.com/waycrate/wayshot/issues/279  
Added a --silent CLI flag to wayshot to allow users to suppress notifications without needing to modify their configuration file.

Changes
wayshot/src/cli.rs
Added the silent boolean flag to the Cli struct, at the end.
```rust
/// Silents notification after screenshot
#[arg(long)]
pub silent: bool,
wayshot/src/wayshot.rs
```
Updated the notification logic to priorities the --silent flag.
wayshot.rs
```rust
let notifications_enabled = !cli.silent && base.notifications.unwrap_or(true);
```