### PR TITLE
Defaulting to Screenshots directory

### DIFF
--- a/docs/wayshot.1.scd
+++ b/docs/wayshot.1.scd
@@ -12,7 +12,7 @@ Wayshot - Screenshot tool for compositors implementing zwlr_screencopy_v1 such a
 
 *output*,
 	Location to send captured screenshot to, it can be of the following types:
-		1. A directory, image outputs will be saved in the default format "wayshot-yyyy-mm-dd-hh-mm-ss.png"
+		1. A directory, image outputs will be saved in the default format "wayshot-yyyy-mm-dd-hh-mm-ss.png" (Parent directories will be created if they do not exist)
 
 		2. A path (Encoding is automatically inferred from the extension).
 

--- a/docs/wayshot.5.scd
+++ b/docs/wayshot.5.scd
@@ -91,7 +91,7 @@ This section documents the *[file]* table of the configuration file
 
 	Refer to _[base]_ category's _file_ for examples
 
-	Default: _"None"_ (current working directory)
+	Default: _"None"_ ($HOME/Pictures/Screenshots, fallbacks to current working directory)
 
 *name_format* = _"<string>"_ | _"None"_
 

--- a/wayshot/src/config.rs
+++ b/wayshot/src/config.rs
@@ -87,10 +87,18 @@ pub struct File {
 impl Default for File {
     fn default() -> Self {
         File {
-            path: Some(env::current_dir().unwrap_or_default()),
+            path: Some(File::get_default_screenshot_dir()),
             name_format: Some("wayshot-%Y_%m_%d-%H_%M_%S".to_string()),
             encoding: Some(EncodingFormat::Png),
         }
+    }
+}
+
+impl File {
+    pub fn get_default_screenshot_dir() -> PathBuf {
+        dirs::picture_dir()
+            .map(|path| path.join("Screenshots"))
+            .unwrap_or_else(|| env::current_dir().unwrap_or_default())
     }
 }
 

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -1,6 +1,6 @@
 use config::Config;
 use std::{
-    env,
+    fs,
     io::{self, BufWriter, Cursor, Write},
 };
 
@@ -101,7 +101,7 @@ fn main() -> Result<()> {
             if base.file.unwrap_or_default() {
                 let dir = file
                     .path
-                    .unwrap_or_else(|| env::current_dir().unwrap_or_default());
+                    .unwrap_or_else(config::File::get_default_screenshot_dir);
                 Some(utils::get_full_file_name(&dir, &file_name_format, encoding))
             } else {
                 None
@@ -262,6 +262,9 @@ fn main() -> Result<()> {
             let mut image_buf: Option<Cursor<Vec<u8>>> = None;
 
             if let Some(f) = file {
+                if let Some(parent) = f.parent() {
+                    fs::create_dir_all(parent)?;
+                }
                 if encoding == EncodingFormat::Jxl {
                     if let Err(e) = utils::encode_to_jxl(
                         &image_buffer,


### PR DESCRIPTION
Changing default saving directory to be `~/Pictures/Screenshots` because all standard tools does this.  
Also nobody would like to fill a random the current working dir to fill with screenshots, scattering them everywhere.

Hence this is lightweight but good default.  
Creating missing parent directories also.