### PR TITLE
chore: restructure CHANGELOG to follow Keep a Changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,51 @@
-# Wayshot
+# Changelog
 
-## [1.4.5] 2026-01-20
+All notable changes to this project will be documented in this file.
 
-### Hot fix: reexport ExtForeignToplevelHandle and fix ci
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.4.5] - 2026-01-20
+
+### Fixed
+- Hot fix: reexport ExtForeignToplevelHandle and fix ci
 
 [1.4.5]: https://github.com/waycrate/wayshot/compare/1.4.5...v1.4.4
 
-## [1.4.4] 2026-01-20
+## [1.4.4] - 2026-01-20
 
-### Hot fix: reexport ExtForeignToplevelHandle
+### Fixed
+- Hot fix: reexport ExtForeignToplevelHandle
 
 [1.4.4]: https://github.com/waycrate/wayshot/compare/1.4.4...v1.4.3
 
-## [1.4.3] 2026-01-20
+## [1.4.3] - 2026-01-20
 
 ### libwayshot 0.7.0
 
-### There is Breaking changes in libwayshot, but it is just some tidy up for the api, mainly the order of params
+### Changed
 - (libwayshot): use the r-egl lib which maintained by waycrate instead of khornos-egl
 - (libwayshot): remove the Instance uses of egl lib. we only use the static feature
 - (libwayshot): make tidy up of the api
 - (libwayshot): Fix the problem that libwayshot panic when there is no support for ext-foreign-toplevel-list
 - (waymirror-egl): tidy up the project, and add it to the workspace. Now it is usable, though still has bugs about keyboard
 
+### Breaking Changes
+- There are breaking changes in libwayshot, but it is just some tidy up for the api, mainly the order of params
+
 [1.4.3]: https://github.com/waycrate/wayshot/compare/1.4.2...v1.4.3
 
 ## [1.4.2] - 2025-12-18
 
-### What's Changed
-- (wayshot): Fix the problem that area selector cannot cross screens.
-- (libwayshot): Handle gbm errors instead of panicking by @dhruvDev23 in #247
+### Added
 - (libwayshot): Enable ext-image-copy by @xonx4l in #245
 - (libwayshot): Add dmabuf screen logic for screencast part by @Decodetalkers in #248
+
+### Changed
+- (libwayshot): Handle gbm errors instead of panicking by @dhruvDev23 in #247
+
+### Fixed
+- (wayshot): Fix the problem that area selector cannot cross screens
 
 ### New Contributors
 - @dhruvDev23 made their first contribution in #247
@@ -40,8 +54,11 @@
 
 ## [1.4.1] - 2025-12-15
 
-* add api for the screencast
-* fix that outputcapture may not get the frameformat sometime
+### Added
+- Add api for the screencast
+
+### Fixed
+- Fix that outputcapture may not get the frameformat sometime
 
 [1.4.1]: https://github.com/waycrate/wayshot/compare/1.4.0...v1.4.1
 
@@ -49,16 +66,21 @@
 
 ### libwayshot 0.4.0
 
-* dmabuf support by @sooraj-satheesh
-* Support JPEG-XL by @Gias002
-* Add unit test by @xonx4l
-* Support ext_\*Protocol by @Rishik-Y
-* Use libwaysip instead of slurp by @Decodetalkers
-* update the libwaysip by @uncomfyhalomacro
+### Added
+- dmabuf support by @sooraj-satheesh
+- Support JPEG-XL by @Gias002
+- Add unit test by @xonx4l
+- Support ext_*Protocol by @Rishik-Y
+- Use libwaysip instead of slurp by @Decodetalkers
+
+### Changed
+- update the libwaysip by @uncomfyhalomacro
+
+### Deprecated
+- screencopy is deprecated now for it has bugs on ext-image-copy. If it is fixed, it will comeback. Now please use screenshot_freeze instead
 
 ### Breaking changes
-* ext-image-copy is supported
-* We have dmabuf support now, though still needs some adjustment
-* screencopy is deprecated now for it has bugs on ext-image-copy. If it is fixed, it will comeback. Now please use screenshot_freeze instead
+- ext-image-copy is supported
+- We have dmabuf support now, though still needs some adjustment
 
 [1.4.0]: https://github.com/waycrate/wayshot/compare/1.3.1...v1.4.0


### PR DESCRIPTION
This PR replaces #297, which was reverted due to incorrect author metadata.

The commit has been recreated with the correct author information. 
No content changes compared to the original PR.
