### PR TITLE
refactor: refactor CI by separating on several files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Wayshot
+name: Build
 
 on: [push, pull_request]
 
@@ -7,149 +7,34 @@ env:
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: all-features
+            cargo_args: --workspace --release --all-features
+          - name: default
+            cargo_args: --workspace --release
+          - name: minimal
+            cargo_args: --workspace --release --no-default-features --features "png"
+
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     container:
       image: archlinux:latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@v6
 
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        components: clippy rustfmt
+      - uses: dtolnay/rust-toolchain@stable
 
-    - name: Build Cache
-      uses: Swatinem/rust-cache@v2
+      - name: Build Cache
+        uses: Swatinem/rust-cache@v2
 
-    - name: Install wayland dependencies
-      run: |
-        pacman -Syu --noconfirm egl-wayland egl-gbm wayland base-devel mesa pango cairo libjxl
-
-    - name: Build
-      run: cargo build --workspace --release
-    - name: Clippy check
-      run:
-        cargo clippy -- -D warnings
-    - name: Check test
-      run: |
-        cargo test --verbose
-
-  coverage:
-    runs-on: ubuntu-latest
-    container:
-      image: archlinux:latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        components: llvm-tools-preview
-    - name: Build Cache
-      uses: Swatinem/rust-cache@v2
-
-    - name: Install wayland dependencies
-      run: |
-        pacman -Syu --noconfirm git egl-wayland egl-gbm wayland base-devel mesa pango cairo libjxl
-
-    - name: Install cargo-llvm-cov
-      uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-llvm-cov
-
-    - name: Generate coverage report
-      run: |
-        cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        files: ./lcov.info
-        fail_ci_if_error: false
-        verbose: true
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  rustfmt:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-
-    - name: Check formatting
-      run: |
-        cargo fmt -- --check
-
-  documentation:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-
-    - name: Check docs
-      run: |
-        sudo apt update
-        sudo apt install --no-install-recommends scdoc
-        for file in $(find . -type f -iwholename "./docs/*.scd"); do scdoc < $file > /dev/null; done
-
-  publish-crate:
-    runs-on: ubuntu-latest
-    container:
-      image: archlinux:latest
-    permissions:
-      contents: write
-      id-token: write
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs:
-      - build
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        persist-credentials: false
-
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        components: clippy rustfmt
-    - name: Install wayland dependencies
-      run: |
-        pacman -Syu --noconfirm egl-wayland egl-gbm wayland base-devel mesa pango cairo libjxl github-cli git
-    - name: Obtain crates.io token
-      uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
-      id: auth
-    - name: Publish to crates.io
-      run: |
-        cargo publish -p libwayshot
-        cargo publish -p wayshot
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        CARGO_PUBLISH: true
-
-  github-release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # required to create release
-      id-token: write # required for OIDC token exchange
-    needs: publish-crate
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: taiki-e/create-gh-release-action@c5baa0b5dc700cf06439d87935e130220a6882d9 # v1.9.3
-        with:
-          branch: main
-          changelog: CHANGELOG.md
-          draft: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish github release
+      - name: Install wayland dependencies
         run: |
-          if [[ $(echo "${GTIHUB_REF#refs/tags/v}" | grep '-' > /dev/null) ]]; then
-            gh release edit "${GITHUB_REF#refs/tags/}" --prerelease
-          fi
-          gh release edit "${GITHUB_REF#refs/tags/}" --draft=false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pacman -Syu --noconfirm egl-wayland egl-gbm wayland base-devel mesa pango cairo libjxl
+
+      - name: Build (${{ matrix.name }})
+        run: cargo build ${{ matrix.cargo_args }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,95 @@
+name: Deploy
+
+on:
+    push:
+        tags:
+            - "v*"
+
+env:
+    CARGO_TERM_COLOR: always
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        container:
+            image: archlinux:latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  persist-credentials: false
+
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                  components: clippy rustfmt
+
+            - name: Install wayland dependencies
+              run: |
+                  pacman -Syu --noconfirm egl-wayland egl-gbm wayland base-devel mesa pango cairo libjxl github-cli git
+
+            - name: Build
+              run: cargo build --workspace --release
+
+    publish-crate:
+        runs-on: ubuntu-latest
+        container:
+            image: archlinux:latest
+        permissions:
+            contents: write
+            id-token: write
+        needs: build
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  persist-credentials: false
+
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                  components: clippy rustfmt
+
+            - name: Install wayland dependencies
+              run: |
+                  pacman -Syu --noconfirm egl-wayland egl-gbm wayland base-devel mesa pango cairo libjxl github-cli git
+
+            - name: Obtain crates.io token
+              uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+              id: auth
+
+            - name: Publish to crates.io
+              run: |
+                  cargo publish -p libwayshot
+                  cargo publish -p wayshot
+              env:
+                  CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+                  CARGO_PUBLISH: true
+
+    github-release:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            id-token: write
+        needs: publish-crate
+
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  persist-credentials: false
+
+            - uses: taiki-e/create-gh-release-action@c5baa0b5dc700cf06439d87935e130220a6882d9 # v1.9.3
+              with:
+                  branch: main
+                  changelog: CHANGELOG.md
+                  draft: true
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Publish github release
+              run: |
+                  if [[ $(echo "${GITHUB_REF#refs/tags/v}" | grep '-' > /dev/null) ]]; then
+                    gh release edit "${GITHUB_REF#refs/tags/}" --prerelease
+                  fi
+                  gh release edit "${GITHUB_REF#refs/tags/}" --draft=false
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,17 @@
+name: Documentation
+
+on: [push, pull_request]
+
+jobs:
+    docs:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Check docs
+              run: |
+                  sudo apt update
+                  sudo apt install --no-install-recommends scdoc
+                  for file in $(find . -type f -iwholename "./docs/*.scd"); do scdoc < $file > /dev/null; done

--- a/.github/workflows/fmt-clippy.yml
+++ b/.github/workflows/fmt-clippy.yml
@@ -1,0 +1,33 @@
+name: fmt and clippy
+
+on: [push, pull_request]
+
+env:
+    CARGO_TERM_COLOR: always
+
+jobs:
+    fmt-clippy:
+        runs-on: ubuntu-latest
+        container:
+            image: archlinux:latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                  components: clippy rustfmt
+
+            - name: Build Cache
+              uses: Swatinem/rust-cache@v2
+
+            - name: Install wayland dependencies
+              run: |
+                  pacman -Syu --noconfirm egl-wayland egl-gbm wayland base-devel mesa pango cairo libjxl
+
+            - name: Check formatting
+              run: cargo fmt -- --check
+
+            - name: Clippy check
+              run: cargo clippy --all-features -- -D warnings

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,65 @@
+name: Test and coverage
+
+on: [push, pull_request]
+
+env:
+    CARGO_TERM_COLOR: always
+
+jobs:
+    test-coverage:
+        runs-on: ubuntu-latest
+        container:
+            image: archlinux:latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                  components: llvm-tools-preview
+
+            - name: Build Cache
+              uses: Swatinem/rust-cache@v2
+
+            - name: Install wayland dependencies
+              run: |
+                  pacman -Syu --noconfirm git egl-wayland egl-gbm wayland base-devel mesa pango cairo libjxl
+
+            - name: Install cargo-llvm-cov
+              uses: taiki-e/install-action@v2
+              with:
+                  tool: cargo-llvm-cov
+
+            - name: Run tests
+              run: cargo test --all-features --verbose
+
+            - name: Generate coverage report (libwayshot)
+              run: |
+                  cargo llvm-cov --all-features -p libwayshot --lcov --output-path lcov-libwayshot.info
+
+            - name: Generate coverage report (wayshot)
+              run: |
+                  cargo llvm-cov --all-features -p wayshot --lcov --output-path lcov-wayshot.info
+
+            - name: Upload libwayshot coverage to Codecov
+              uses: codecov/codecov-action@v5
+              with:
+                  files: ./lcov-libwayshot.info
+                  flags: libwayshot
+                  name: libwayshot
+                  fail_ci_if_error: false
+                  verbose: true
+              env:
+                  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+            - name: Upload wayshot coverage to Codecov
+              uses: codecov/codecov-action@v5
+              with:
+                  files: ./lcov-wayshot.info
+                  flags: wayshot
+                  name: wayshot
+                  fail_ci_if_error: false
+                  verbose: true
+              env:
+                  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -2,11 +2,11 @@
 # yamllint disable rule:line-length
 name: check_typos
 
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   push:
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 jobs:
   build:


### PR DESCRIPTION
Mostly moving stuff around, but minor changes included:
- build three patterns: `all-features`, `default-features`, `minimal` (with just `png` feature)
- separate coverage reports for `libwayshot` and `wayshot`

Also, left unchanged, but in #234 @Shinyzenith mentioned that probably we don't need to distribute binaries with release, maybe we should remove this part of job? If not, we should probably add `all-features` to it? Or distribute several flavors? Or just the `default`? I'm not sure what'd be best here.