### PR TITLE
fix: do not always init drm when it is not needed

### DIFF
--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -108,6 +108,7 @@ pub struct WayshotConnection {
     dmabuf_state: Option<DMABUFState>,
     toplevel_capture_support: bool,
     image_copy_support: bool,
+    find_dmabuf: bool,
 }
 
 pub enum WayshotFrame {
@@ -184,6 +185,7 @@ impl WayshotConnection {
             dmabuf_state: None,
             toplevel_capture_support,
             image_copy_support,
+            find_dmabuf: false,
         };
 
         initial_state.refresh_outputs()?;
@@ -194,6 +196,11 @@ impl WayshotConnection {
 
     fn has_gbm(&self) -> bool {
         self.dmabuf_state.is_some()
+    }
+
+    // NOTE: this function says if we need to try receive the gdm information from ext-image-copy
+    fn need_try_find_gbm(&self) -> bool {
+        !self.has_gbm() && self.find_dmabuf
     }
     ///Create a WayshotConnection struct having DMA-BUF support
     /// Using this connection is required to make use of the dmabuf functions
@@ -223,6 +230,7 @@ impl WayshotConnection {
             }),
             toplevel_capture_support,
             image_copy_support,
+            find_dmabuf: false,
         };
 
         initial_state.refresh_outputs()?;
@@ -305,7 +313,7 @@ impl WayshotConnection {
     }
 
     pub fn refresh_toplevels(&mut self) -> Result<()> {
-        let mut state = CaptureFrameState::new(!self.has_gbm());
+        let mut state = CaptureFrameState::new(self.need_try_find_gbm());
 
         let mut event_queue = self.conn.new_event_queue::<CaptureFrameState>();
         let qh = event_queue.handle();
@@ -762,7 +770,7 @@ impl WayshotConnection {
         EventQueue<CaptureFrameState>,
         WayshotFrame,
     )> {
-        let state = CaptureFrameState::new(!self.has_gbm());
+        let state = CaptureFrameState::new(self.need_try_find_gbm());
         let event_queue = self.conn.new_event_queue::<CaptureFrameState>();
         let qh = event_queue.handle();
         match self
@@ -1510,7 +1518,7 @@ impl WayshotConnection {
         WayshotFrame,
     )> {
         // Create state and event queue similar to other ext-image flows
-        let mut state = CaptureFrameState::new(!self.has_gbm());
+        let mut state = CaptureFrameState::new(self.need_try_find_gbm());
         let mut event_queue = self.conn.new_event_queue::<CaptureFrameState>();
         let qh = event_queue.handle();
 

--- a/libwayshot/src/screencast.rs
+++ b/libwayshot/src/screencast.rs
@@ -66,6 +66,7 @@ impl WayshotConnection {
     /// This will run once to get the device provided by ext-image-copy. If you did not init the
     /// dmabuf at the first, you can try to use this way to init one
     pub fn try_init_dmabuf(&mut self, target: WayshotTarget) -> Result<()> {
+        self.find_dmabuf = true;
         if self.dmabuf_state.is_some() {
             return Ok(());
         }

--- a/waymirror-egl/src/state.rs
+++ b/waymirror-egl/src/state.rs
@@ -129,12 +129,9 @@ impl WaylandEGLState {
             Some(egl_context),
         )?;
 
-        let wayshot = WayshotConnection::from_connection_with_dmabuf(
-            server_connection,
-            "/dev/dri/renderD128",
-        )
-        .unwrap();
+        let mut wayshot = WayshotConnection::from_connection(server_connection).unwrap();
         let target = WayshotTarget::Screen(wayshot.get_all_outputs()[0].wl_output.clone());
+        wayshot.try_init_dmabuf(target.clone()).unwrap();
         let cast = init_cast(&wayshot, target, 0, egl_display);
         Ok((
             Self {


### PR DESCRIPTION
only when we tell the thread that we need to find one, else we do not need it

resolve: https://github.com/waycrate/wayshot/issues/325