### PR TITLE
fix: ensure frame synchronization after FrameState::Finished to preve…

### DIFF
--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -876,8 +876,8 @@ impl WayshotConnection {
         // On copy the Ready / Failed events are fired by the frame object, so here we check for them.
         loop {
             // Basically reads, if frame state is not None then...
-            if let Some(state) = state.state {
-                match state {
+            if let Some(frame_state) = state.state {
+                match frame_state {
                     FrameState::Failed => {
                         tracing::error!("Frame copy failed");
                         return Err(Error::FramecopyFailed);
@@ -887,6 +887,7 @@ impl WayshotConnection {
                         return Err(Error::FramecopyFailedWithReason(reason));
                     }
                     FrameState::Finished => {
+                        event_queue.roundtrip(&mut state)?;
                         tracing::trace!("Frame copy finished");
                         return Ok(DMAFrameGuard {
                             buffer: dmabuf_wlbuf,
@@ -949,8 +950,8 @@ impl WayshotConnection {
         // On copy the Ready / Failed events are fired by the frame object, so here we check for them.
         loop {
             // Basically reads, if frame state is not None then...
-            if let Some(state) = state.state {
-                match state {
+            if let Some(frame_state) = state.state {
+                match frame_state {
                     FrameState::Failed => {
                         tracing::error!("Frame copy failed");
                         return Err(Error::FramecopyFailed);
@@ -960,8 +961,8 @@ impl WayshotConnection {
                         return Err(Error::FramecopyFailedWithReason(reason));
                     }
                     FrameState::Finished => {
+                        event_queue.roundtrip(&mut state)?;
                         tracing::trace!("Frame copy finished");
-
                         return Ok(DMAFrameGuard {
                             buffer: dmabuf_wlbuf,
                         });
@@ -1028,13 +1029,14 @@ impl WayshotConnection {
         // On copy the Ready / Failed events are fired by the frame object, so here we check for them.
         loop {
             // Basically reads, if frame state is not None then...
-            if let Some(state) = state.state {
-                match state {
+            if let Some(frame_state) = state.state {
+                match frame_state {
                     FrameState::Failed | FrameState::FailedWithReason(_) => {
                         tracing::error!("Frame copy failed");
                         return Err(Error::FramecopyFailed);
                     }
                     FrameState::Finished => {
+                        event_queue.roundtrip(&mut state)?;
                         tracing::trace!("Frame copy finished");
                         return Ok(FrameGuard {
                             buffer,
@@ -1087,8 +1089,8 @@ impl WayshotConnection {
         // On copy the Ready / Failed events are fired by the frame object, so here we check for them.
         loop {
             // Basically reads, if frame state is not None then...
-            if let Some(state) = state.state {
-                match state {
+            if let Some(frame_state) = state.state {
+                match frame_state {
                     FrameState::Failed => {
                         tracing::error!("Frame copy failed");
                         return Err(Error::FramecopyFailed);
@@ -1098,6 +1100,7 @@ impl WayshotConnection {
                         return Err(Error::FramecopyFailedWithReason(reason));
                     }
                     FrameState::Finished => {
+                        event_queue.roundtrip(&mut state)?;
                         tracing::trace!("Frame copy finished");
                         return Ok(FrameGuard {
                             buffer,


### PR DESCRIPTION
Returning immediately after `FrameState::Finished` can result in corrupted
captures (e.g., banding or stale regions), especially on high refresh rate
displays.

This change adds a Wayland event queue synchronization step (`roundtrip`)
after `Finished` before returning the captured buffer.

Without this, the SHM buffer may be consumed before all relevant events
have been fully processed. Adding the synchronization ensures the frame
is fully ready before use.

This behavior was reproducible on Hyprland (144 Hz), and the fix eliminates
the issue consistently.

Tested by:
- comparing against grim output (which does not exhibit the issue)
- verifying removal of banding artifacts across repeated runs. 

For more information please see #327