### PR TITLE
fix: use correct resolver version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = ["wayshot", "libwayshot", "./waymirror-egl"]
 default-members = ["wayshot", "libwayshot"]
 


### PR DESCRIPTION
Since we already use `edition = "2024"`, we must use `resolver = "3"` also, see official docs: https://doc.rust-lang.org/edition-guide/rust-2024/cargo-resolver.html