### PR TITLE
fix: make cargo doc pass without warns

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,12 @@ name: Documentation
 
 on: [push, pull_request]
 
+env:
+    CARGO_TERM_COLOR: always
+
+permissions:
+    contents: read
+
 jobs:
     docs:
         runs-on: ubuntu-latest
@@ -15,3 +21,22 @@ jobs:
                   sudo apt update
                   sudo apt install --no-install-recommends scdoc
                   for file in $(find . -type f -iwholename "./docs/*.scd"); do scdoc < $file > /dev/null; done
+
+    rust-doc:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v6
+            - uses: dtolnay/rust-toolchain@stable
+            - name: Build cache
+              uses: Swatinem/rust-cache@v2
+            - name: Install system dependencies
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y \
+                    pkg-config \
+                    libwayland-dev
+            - name: Doc
+              run: cargo doc --workspace --no-deps --all-features
+              env:
+                  RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,8 @@ jobs:
 
     rust-doc:
         runs-on: ubuntu-latest
+        container:
+            image: archlinux:latest
 
         steps:
             - uses: actions/checkout@v6
@@ -32,10 +34,7 @@ jobs:
               uses: Swatinem/rust-cache@v2
             - name: Install system dependencies
               run: |
-                  sudo apt-get update
-                  sudo apt-get install -y \
-                    pkg-config \
-                    libwayland-dev
+                  pacman -Syu --noconfirm git egl-wayland egl-gbm wayland base-devel mesa pango cairo libjxl
             - name: Doc
               run: cargo doc --workspace --no-deps --all-features
               env:

--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -361,7 +361,7 @@ impl WayshotConnection {
     /// # Parameters
     /// - `output`: Reference to the [WayshotTarget] to inspect.
     /// # Returns
-    /// - A vector of [`FrameFormat`] if screen capture succeeds.
+    /// - A vector of `FrameFormat` if screen capture succeeds.
     /// - [`Error::ProtocolNotFound`] if wlr-screencopy protocol is not found.
     pub fn get_available_frame_formats(&self, target: &WayshotTarget) -> Result<Vec<FrameFormat>> {
         let state = match target {
@@ -387,7 +387,7 @@ impl WayshotConnection {
     /// - `frame_format`: `wl_shm::Format` to use for screen capture.
     /// - `capture_region`: Optional region specifying a sub-area of the output to capture. If `None`, the entire output is captured.
     /// # Returns
-    /// - A [`FrameGuard`] instance that holds the screen capture result, if screen capture is successful and frame_format is supported.
+    /// - A `FrameGuard` instance that holds the screen capture result, if screen capture is successful and frame_format is supported.
     /// - [`Error::FramecopyFailed`] if screen capture fails.
     /// - [`Error::NoSupportedBufferFormat`] if frame_format is not supported for the given output.
     pub fn capture_output_frame_shm_fd_with_format<T: AsFd>(
@@ -447,7 +447,7 @@ impl WayshotConnection {
 
         Ok((frame_format, frame_guard))
     }
-    /// Helper function/wrapper that uses the OpenGL extension OES_EGL_image to convert the EGLImage obtained from [`WayshotConnection::capture_output_frame_eglimage`]
+    /// Helper function/wrapper that uses the OpenGL extension OES_EGL_image to convert the EGLImage obtained from [`WayshotConnection::capture_target_frame_eglimage`]
     /// into a OpenGL texture.
     /// - The caller is supposed to setup everything required for the texture binding. An example call may look like:
     /// ```no_run, ignore
@@ -733,8 +733,8 @@ impl WayshotConnection {
         Ok((state, event_queue, frame, frame_format))
     }
 
-    /// Capture the target the the current state, the result include [CaptureFrameState],
-    /// [EventQueue<CaptureFrameState>] and a [WayshotFrame]
+    /// Capture the target the the current state, the result include `CaptureFrameState`,
+    /// `EventQueue<CaptureFrameState>` and a [WayshotFrame]
     pub fn capture_target_frame_get_state(
         &self,
         target: &WayshotTarget,

--- a/libwayshot/src/region.rs
+++ b/libwayshot/src/region.rs
@@ -68,7 +68,7 @@ pub struct LogicalRegion {
 ///
 /// Example:
 ///
-/// ````ignore
+/// ```text
 /// ┌─────────────┐
 /// │             │
 /// │  ┌──────────┼──────┐
@@ -84,7 +84,7 @@ pub struct LogicalRegion {
 /// │             │
 /// │    Screen 1 │
 /// └─────────────┘
-/// ````
+/// ```
 #[derive(Debug, Copy, Clone)]
 pub struct EmbeddedRegion {
     /// The coordinate sysd

--- a/libwayshot/src/screencast.rs
+++ b/libwayshot/src/screencast.rs
@@ -87,7 +87,7 @@ impl WayshotConnection {
     /// This will save a screencast status for you
     /// We suggest you to use this api to do screencast
     /// Same with create_screencast_with_shm, but now it is with dmabuf
-    /// And bind the a [crate::egl::EglDisplay], to support the egl
+    /// And bind the a `EglDisplay`, to support the egl
     #[cfg(feature = "egl")]
     pub fn create_screencast_with_egl(
         &self,


### PR DESCRIPTION
`cargo doc` job will help us catch warns in doc entries so docs.rs page stays happy