### PR TITLE
feature: add configuration for notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changes on `main` since **[1.4.6](https://github.com/waycrate/wayshot/releases/t
 #### Added
 
 - Cargo **features** gating **clipboard**, **color picker**, **logger**, **notifications**, **selector**, **AVIF**, and **JPEG XL** ([#306](https://github.com/waycrate/wayshot/pull/306), [@Gigas002](https://github.com/Gigas002)).
+- extended **`[notification]`** config: `icon`, `timeout_ms`, `urgency`, `app_name`, `success_summary`, `failure_summary`, `sound_name`, `transient`, `category` ([@Gigas002](https://github.com/Gigas002)).
 - split CLI implementation into focused modules (`clipboard`, `color_picker`, `notification`, `logger`, `screenshot`, …) ([#306](https://github.com/waycrate/wayshot/pull/306), [@Gigas002](https://github.com/Gigas002)).
 - **Freeze** before capture is **on by default**; set **`freeze`** in config, or pass **`--no-freeze`** on the CLI to disable (same idea as notifications) ([#309](https://github.com/waycrate/wayshot/pull/309), [@Gigas002](https://github.com/Gigas002)).
 - **`--delay`** before taking the shot ([#318](https://github.com/waycrate/wayshot/pull/318), [@Gigas002](https://github.com/Gigas002)).

--- a/config.toml
+++ b/config.toml
@@ -96,10 +96,6 @@ effort = 7
 # -1 = never expire, 0 = server default, positive = milliseconds.
 # timeout_ms = 5000
 
-# Urgency level: "low", "normal", or "critical".
-# Critical notifications do not time out on most servers.
-# urgency = "normal"
-
 # Application name shown in the notification.
 # app_name = "wayshot"
 

--- a/config.toml
+++ b/config.toml
@@ -88,3 +88,33 @@ effort = 7
 # The command is run exactly as provided with no arguments appended.
 # If not set, opens the screenshot directory with xdg-open.
 # action = "xdg-open PATH"
+
+# Icon name shown in the notification (uses icon theme lookup).
+# icon = "camera-photo"
+
+# How long the notification is visible, in milliseconds.
+# -1 = never expire, 0 = server default, positive = milliseconds.
+# timeout_ms = 5000
+
+# Urgency level: "low", "normal", or "critical".
+# Critical notifications do not time out on most servers.
+# urgency = "normal"
+
+# Application name shown in the notification.
+# app_name = "wayshot"
+
+# Custom title for the success notification.
+# success_summary = "Screenshot Taken"
+
+# Custom title for the failure notification.
+# failure_summary = "Screenshot Failed"
+
+# XDG sound name to play when the notification appears.
+# sound_name = "message-new-instant"
+
+# If true, the notification is transient and won't persist in notification
+# center / history after it is dismissed.
+# transient = false
+
+# Notification category hint (e.g. "transfer.complete", "im.received").
+# category = "transfer.complete"

--- a/docs/wayshot.5.scd
+++ b/docs/wayshot.5.scd
@@ -261,13 +261,6 @@ _Requires the_ *notifications* _feature (enabled by default)._
 
 	Default: _5000_
 
-*urgency* = _"low"_ | _"normal"_ | _"critical"_
-
-	Urgency level of the notification.
-	Most notification servers do not dismiss *critical* notifications automatically.
-
-	Default: _"normal"_
-
 *app_name* = _"<string>"_
 
 	Application name field sent with the notification.

--- a/docs/wayshot.5.scd
+++ b/docs/wayshot.5.scd
@@ -239,6 +239,84 @@ _Requires the_ *notifications* _feature (enabled by default)._
 
 	Default: _xdg-open <screenshot directory>_
 
+*icon* = _"<string>"_
+
+	Icon name passed to the notification daemon. The daemon resolves it
+	against its own configured icon theme — not *XDG_ICON_THEME*. Set the
+	theme in your daemon's configuration (e.g. *icon_theme* in dunstrc).
+
+	Examples:
+		- icon = "accessories-camera" (candy-icons theme)
+		- icon = "camera-photo"
+
+	Default: _unset_ (daemon chooses its own default)
+
+*timeout_ms* = _<integer>_
+
+	How long the notification stays visible, in milliseconds.
+
+	- _-1_: never expire
+	- _0_: use the notification server's default
+	- positive integer: display for this many milliseconds
+
+	Default: _5000_
+
+*urgency* = _"low"_ | _"normal"_ | _"critical"_
+
+	Urgency level of the notification.
+	Most notification servers do not dismiss *critical* notifications automatically.
+
+	Default: _"normal"_
+
+*app_name* = _"<string>"_
+
+	Application name field sent with the notification.
+	Visible in some notification daemons and used for daemon-side filtering rules.
+
+	Default: _"wayshot"_
+
+*success_summary* = _"<string>"_
+
+	Title shown in the notification after a successful screenshot.
+
+	Default: _"Screenshot Taken"_
+
+*failure_summary* = _"<string>"_
+
+	Title shown in the notification when a screenshot fails.
+
+	Default: _"Screenshot Failed"_
+
+*sound_name* = _"<string>"_
+
+	XDG sound name hint sent with the notification.
+	Only respected by notification daemons that implement the freedesktop sound
+	hint (e.g. GNOME Shell, KDE Plasma). Standalone daemons such as *dunst* and
+	*mako* ignore this field — use their scripting feature to play sounds instead.
+
+	Example: sound_name = "message-new-instant"
+
+	Default: _unset_
+
+*transient* = _true_ | _false_
+
+	When true, marks the notification as transient. Transient notifications are
+	not stored in notification history or the notification center after dismissal.
+	Support depends on the notification daemon.
+
+	Default: _false_
+
+*category* = _"<string>"_
+
+	Notification category hint (freedesktop standard).
+	Can be used by notification daemons for filtering or styling rules.
+
+	Examples:
+		- category = "transfer.complete"
+		- category = "im.received"
+
+	Default: _unset_
+
 # SEE ALSO
 	- wayshot(1)
 	- wayshot(7)

--- a/wayshot/src/config.rs
+++ b/wayshot/src/config.rs
@@ -236,8 +236,6 @@ pub struct NotificationConfig {
     pub icon: Option<String>,
     /// Duration in milliseconds. -1 = never expire, 0 = server default.
     pub timeout_ms: Option<i32>,
-    /// Urgency level: "low", "normal", or "critical".
-    pub urgency: Option<String>,
     /// Application name shown in the notification.
     pub app_name: Option<String>,
     /// Title for the success notification.

--- a/wayshot/src/config.rs
+++ b/wayshot/src/config.rs
@@ -232,4 +232,22 @@ impl Png {
 pub struct NotificationConfig {
     /// Shell command to run when the notification is clicked.
     pub action: Option<String>,
+    /// Notification icon name (e.g. "camera-photo").
+    pub icon: Option<String>,
+    /// Duration in milliseconds. -1 = never expire, 0 = server default.
+    pub timeout_ms: Option<i32>,
+    /// Urgency level: "low", "normal", or "critical".
+    pub urgency: Option<String>,
+    /// Application name shown in the notification.
+    pub app_name: Option<String>,
+    /// Title for the success notification.
+    pub success_summary: Option<String>,
+    /// Title for the failure notification.
+    pub failure_summary: Option<String>,
+    /// XDG sound name to play (e.g. "message-new-instant").
+    pub sound_name: Option<String>,
+    /// Transient hint: notification won't persist in notification center.
+    pub transient: Option<bool>,
+    /// Notification category hint (e.g. "transfer.complete", "im.received").
+    pub category: Option<String>,
 }

--- a/wayshot/src/notification.rs
+++ b/wayshot/src/notification.rs
@@ -1,19 +1,20 @@
 //! Desktop notifications via `notify-rust` (D-Bus / libnotify).
 
 use eyre::Error;
-use notify_rust::Notification;
+use notify_rust::{Hint, Notification, Urgency};
 use rustix::runtime::{self, Fork};
 use std::path::Path;
 use std::process::Command;
 
+use crate::config::NotificationConfig;
 use crate::screenshot::ShotResult;
 
-const TIMEOUT_MS: i32 = 5000;
+const DEFAULT_TIMEOUT_MS: i32 = 5000;
 
 pub fn send_success(
     result: &ShotResult,
     saved_location: Option<&Path>,
-    action_command: Option<&str>,
+    config: &NotificationConfig,
 ) {
     let body = match result {
         ShotResult::Output { name } => format!("Screenshot of output '{name}' saved"),
@@ -22,11 +23,8 @@ pub fn send_success(
         ShotResult::All => "Screenshot of all outputs saved".to_string(),
     };
 
-    let mut notification = Notification::new();
-    notification
-        .summary("Screenshot Taken")
-        .appname("wayshot")
-        .timeout(TIMEOUT_MS);
+    let mut notification = build_base_notification(config, true);
+    notification.body(&body);
 
     if let Some(path) = saved_location {
         let dir_path = path
@@ -43,8 +41,8 @@ pub fn send_success(
                 if let Ok(handle) = notification.show() {
                     handle.wait_for_action(|action| {
                         if action == "open_location" || action == "default" {
-                            let cmd = match action_command {
-                                Some(custom) => custom.to_string(),
+                            let cmd = match &config.action {
+                                Some(custom) => custom.clone(),
                                 None => format!("xdg-open {dir_path}"),
                             };
                             let _ = Command::new("sh")
@@ -60,18 +58,64 @@ pub fn send_success(
             Ok(Fork::ParentOf(_)) => {}
             Err(e) => {
                 tracing::error!("Fork failed for notification action: {}", e);
-                let _ = notification.body(&body).show();
+                let _ = notification.show();
             }
         }
     } else {
-        let _ = notification.body(&body).show();
+        let _ = notification.show();
     }
 }
 
-pub fn send_failure(error: &Error) {
-    let _ = Notification::new()
-        .summary("Screenshot Failed")
+pub fn send_failure(error: &Error, config: &NotificationConfig) {
+    let _ = build_base_notification(config, false)
         .body(&error.to_string())
-        .timeout(TIMEOUT_MS)
         .show();
+}
+
+fn build_base_notification(config: &NotificationConfig, is_success: bool) -> Notification {
+    let default_summary = if is_success {
+        "Screenshot Taken"
+    } else {
+        "Screenshot Failed"
+    };
+    let summary = if is_success {
+        config.success_summary.as_deref().unwrap_or(default_summary)
+    } else {
+        config.failure_summary.as_deref().unwrap_or(default_summary)
+    };
+
+    let mut n = Notification::new();
+    n.summary(summary)
+        .appname(config.app_name.as_deref().unwrap_or("wayshot"))
+        .timeout(config.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS));
+
+    if let Some(icon) = &config.icon {
+        n.icon(icon);
+    }
+
+    if let Some(urgency) = &config.urgency {
+        n.urgency(parse_urgency(urgency));
+    }
+
+    if let Some(sound) = &config.sound_name {
+        n.sound_name(sound);
+    }
+
+    if let Some(transient) = config.transient {
+        n.hint(Hint::Transient(transient));
+    }
+
+    if let Some(category) = &config.category {
+        n.hint(Hint::Category(category.clone()));
+    }
+
+    n
+}
+
+fn parse_urgency(s: &str) -> Urgency {
+    match s.to_lowercase().as_str() {
+        "low" => Urgency::Low,
+        "critical" => Urgency::Critical,
+        _ => Urgency::Normal,
+    }
 }

--- a/wayshot/src/notification.rs
+++ b/wayshot/src/notification.rs
@@ -24,6 +24,7 @@ pub fn send_success(
     };
 
     let mut notification = build_base_notification(config, true);
+    notification.urgency(Urgency::Normal);
     notification.body(&body);
 
     if let Some(path) = saved_location {
@@ -68,6 +69,7 @@ pub fn send_success(
 
 pub fn send_failure(error: &Error, config: &NotificationConfig) {
     let _ = build_base_notification(config, false)
+        .urgency(Urgency::Critical)
         .body(&error.to_string())
         .show();
 }
@@ -93,10 +95,6 @@ fn build_base_notification(config: &NotificationConfig, is_success: bool) -> Not
         n.icon(icon);
     }
 
-    if let Some(urgency) = &config.urgency {
-        n.urgency(parse_urgency(urgency));
-    }
-
     if let Some(sound) = &config.sound_name {
         n.sound_name(sound);
     }
@@ -110,12 +108,4 @@ fn build_base_notification(config: &NotificationConfig, is_success: bool) -> Not
     }
 
     n
-}
-
-fn parse_urgency(s: &str) -> Urgency {
-    match s.to_lowercase().as_str() {
-        "low" => Urgency::Low,
-        "critical" => Urgency::Critical,
-        _ => Urgency::Normal,
-    }
 }

--- a/wayshot/src/settings.rs
+++ b/wayshot/src/settings.rs
@@ -52,7 +52,7 @@ pub(crate) struct AppSettings {
     #[cfg(feature = "notifications")]
     pub(crate) notifications: bool,
     #[cfg(feature = "notifications")]
-    pub(crate) notification_action: Option<String>,
+    pub(crate) notification: config::NotificationConfig,
 }
 
 impl AppSettings {
@@ -153,7 +153,7 @@ impl AppSettings {
             #[cfg(feature = "notifications")]
             notifications: !cli.silent && base.notifications.unwrap_or(true),
             #[cfg(feature = "notifications")]
-            notification_action: config.notification.as_ref().and_then(|n| n.action.clone()),
+            notification: config.notification.clone().unwrap_or_default(),
         }
     }
 

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -97,7 +97,7 @@ fn main() -> Result<()> {
                         notification::send_success(
                             &shot_result,
                             settings.file.as_deref(),
-                            settings.notification_action.as_deref(),
+                            &settings.notification,
                         );
                     }
                     // Silence unused warning when the notifications feature is disabled.
@@ -109,7 +109,7 @@ fn main() -> Result<()> {
                 Err(e) => {
                     #[cfg(feature = "notifications")]
                     if settings.notifications {
-                        notification::send_failure(&e);
+                        notification::send_failure(&e, &settings.notification);
                     }
                     Err(e)
                 }


### PR DESCRIPTION
Closes: #334 

Actual notification features differs depending on user's notification daemon, e.g. most lightweight daemons like `dunst` or `mako` doesn't support sound playback, so the parameter doesn't have any effect.

Examples:

<img width="356" height="132" alt="image" src="https://github.com/user-attachments/assets/cd288e3e-1524-4370-9263-9947a1f1b3a3" />

<img width="347" height="117" alt="image" src="https://github.com/user-attachments/assets/86806049-eb2b-491a-a8d0-d52c977ad9e1" />
