### PR TITLE
fix: fix unexpected behavior on geometry cancelation

### DIFF
--- a/wayshot/src/settings.rs
+++ b/wayshot/src/settings.rs
@@ -171,7 +171,11 @@ impl AppSettings {
                         std::process::exit(1);
                     }
                 },
-                Some(_) | None => {
+                Some(_) => {
+                    tracing::error!("geometry string is empty or incorrect");
+                    std::process::exit(1);
+                }
+                None => {
                     #[cfg(feature = "selector")]
                     return CaptureMode::Geometry {
                         foreground_color: cli


### PR DESCRIPTION
Before that, geometry selector's cancellation didn't trigger correct branch in check and that resulted in panic much later. Handle this correctly.

```sh
 ~/documents/repos/wayshot/target/release  [ fix/bad-geometry-fail][!][+5][-1][⏱️ 1s471ms][17:05:49 16.05.2026]
❯ ./wayshot -g $"(waysip -d)"
Selection canceled
2026-05-16T08:05:50.516679Z ERROR wayshot::settings: geometry string is empty or incorrect
```