### PR TITLE
Improve Nix flake and add flake.lock update action

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1774709303,
@@ -34,24 +16,8 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1772328832,
-        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,40 +1,74 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs = inputs@{ flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  outputs =
+    { self, nixpkgs }:
+    let
+      forAllSystems =
+        callback:
+        nixpkgs.lib.genAttrs [
+          "x86_64-linux"
+          "aarch64-linux"
+        ] (system: callback nixpkgs.legacyPackages.${system});
 
-      perSystem = { pkgs, system, ... }:
+      mkDeps =
+        pkgs: with pkgs; [
+          pango
+          libgbm
+          libGL
+          wayland
+        ];
+    in
+    {
+      packages = forAllSystems (
+        pkgs:
         let
-          deps = with pkgs; [ pango libgbm libGL wayland ];
+          inherit (pkgs) lib;
         in
         {
-          packages.default = pkgs.rustPlatform.buildRustPackage {
+          default = pkgs.rustPlatform.buildRustPackage (finalAttrs: {
             pname = "wayshot";
-            version = "1.4.6";
+            version = "${(builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version}-git";
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = [ pkgs.pkg-config ];
-            buildInputs = deps;
-          };
+            buildInputs = mkDeps pkgs;
 
-          devShells.default = pkgs.mkShell {
-            strictDeps = true;
-            nativeBuildInputs = with pkgs; [
-              cargo
-              rustc
-              rust-analyzer
-              clippy
-              rustfmt
-              pkg-config
-            ];
-            buildInputs = deps;
-            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath deps;
-          };
-        };
+            meta = {
+              description = "Screenshot crate for wlroots based compositors implementing the zwlr_screencopy_v1 protocol.";
+              homepage = "https://crates.io/crates/wayshot";
+              changelog = "https://github.com/waycrate/wayshot/releases/tag/v${finalAttrs.version}";
+              license = with lib.licenses; [
+                bsd2
+                gpl3Only
+              ];
+              mainProgram = "wayshot";
+              platforms = lib.platforms.linux;
+            };
+          });
+        }
+      );
+
+      devShells.default = forAllSystems (
+        pkgs:
+        let
+          inherit (pkgs) lib;
+        in
+        pkgs.mkShell {
+          strictDeps = true;
+          nativeBuildInputs = with pkgs; [
+            cargo
+            rustc
+            rust-analyzer
+            clippy
+            rustfmt
+            pkg-config
+          ];
+          buildInputs = mkDeps pkgs;
+          LD_LIBRARY_PATH = lib.makeLibraryPath (mkDeps pkgs);
+        }
+      );
     };
 }


### PR DESCRIPTION
- Remove redundant `flake-parts` input
- Automatically grab package version from `Cargo.toml` (version was outdated previously)
- Add meta tags
- Add flake.lock update GitHub action (I couldn't find one here)

Not sure if this makes sense if this is already in Nixpkgs

Feel free to reuse this

If you want, I can also make PRs improving the flakes of some other waycrate projects.
