### PR TITLE
chore(screenshot)!: use identifier to select toplevel

### DIFF
--- a/docs/wayshot.1.scd
+++ b/docs/wayshot.1.scd
@@ -40,7 +40,7 @@ Wayshot - Screenshot tool for compositors implementing zwlr_screencopy_v1 such a
 	List all connected outputs with their name, description, size, and position.
 
 *--list-toplevels*, *--list-windows*
-	List all active toplevel windows.
+	List all active toplevel windows, with app_id, title and identifier
 
 *--color*
 	Click a pixel and print its RGBA and hex color value. By default the screen is frozen first;
@@ -76,8 +76,8 @@ Wayshot - Screenshot tool for compositors implementing zwlr_screencopy_v1 such a
 *--choose-output*
 	Present a fuzzy selector for output/display selection.
 
-*--toplevel <APP_ID TITLE>*, *--window <APP_ID TITLE>*
-	Capture a specific toplevel window identified by its "app_id title" string.
+*--toplevel <Identifier>*, *--window <Identifier>*
+	Capture a specific toplevel window identified by its "identifier" string.
 	Use *--list-toplevels* to discover available strings.
 
 *--choose-toplevel*, *--choose-window*

--- a/libwayshot/src/region.rs
+++ b/libwayshot/src/region.rs
@@ -51,6 +51,9 @@ impl TopLevel {
     pub fn id_and_title(&self) -> String {
         format!("{} {}", self.app_id, self.title)
     }
+    pub fn id_title_identifier(&self) -> String {
+        format!("{} {} {}", self.app_id, self.title, self.identifier)
+    }
 }
 
 /// `Region` where the coordinate system is the logical coordinate system used

--- a/libwayshot/src/region.rs
+++ b/libwayshot/src/region.rs
@@ -52,7 +52,10 @@ impl TopLevel {
         format!("{} {}", self.app_id, self.title)
     }
     pub fn id_title_identifier(&self) -> String {
-        format!("{} {} {}", self.app_id, self.title, self.identifier)
+        format!(
+            "app_id: \"{}\", title: \"{}\", identifier:\"{}\"",
+            self.app_id, self.title, self.identifier
+        )
     }
 }
 

--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -61,7 +61,7 @@ pub struct Cli {
     #[arg(long)]
     pub list_outputs_info: bool,
 
-    /// List all active toplevel windows.
+    /// List all active toplevel windows. you will the information about id+title+identifier
     #[arg(long, alias = "list-windows")]
     pub list_toplevels: bool,
 
@@ -96,7 +96,7 @@ pub struct Cli {
     #[arg(long, alias = "choose-output", conflicts_with_all = ["geometry", "output"])]
     pub choose_output: bool,
 
-    /// Capture a specific toplevel window by its "app_id title" string.
+    /// Capture a specific toplevel window by its identifier string.
     #[arg(long, alias = "window", conflicts_with_all = ["geometry", "output", "choose_output", "choose_toplevel"])]
     pub toplevel: Option<String>,
 

--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -61,7 +61,7 @@ pub struct Cli {
     #[arg(long)]
     pub list_outputs_info: bool,
 
-    /// List all active toplevel windows. you will the information about id+title+identifier
+    /// List all active toplevel windows. You will see the information about id+title+identifier
     #[arg(long, alias = "list-windows")]
     pub list_toplevels: bool,
 

--- a/wayshot/src/notification.rs
+++ b/wayshot/src/notification.rs
@@ -17,7 +17,9 @@ pub fn send_success(
 ) {
     let body = match result {
         ShotResult::Output { name } => format!("Screenshot of output '{name}' saved"),
-        ShotResult::Toplevel { name } => format!("Screenshot of toplevel '{name}' saved"),
+        ShotResult::Toplevel { identifier } => {
+            format!("Screenshot of toplevel '{identifier}' saved")
+        }
         ShotResult::Area => "Screenshot of selected area saved".to_string(),
         ShotResult::All => "Screenshot of all outputs saved".to_string(),
     };

--- a/wayshot/src/screenshot.rs
+++ b/wayshot/src/screenshot.rs
@@ -9,7 +9,7 @@ use libwayshot::WayshotConnection;
 #[cfg_attr(not(feature = "notifications"), allow(dead_code))]
 pub enum ShotResult {
     Output { name: String },
-    Toplevel { name: String },
+    Toplevel { identifier: String },
     Area,
     All,
 }
@@ -24,7 +24,7 @@ pub enum CaptureMode {
     },
     /// A fixed region parsed from a slurp/waysip geometry string.
     GeometryRegion(libwayshot::LogicalRegion),
-    /// A specific toplevel window by its id+title string.
+    /// A specific toplevel window by its identifier string.
     Toplevel(String),
     /// Interactive fuzzy-select from active toplevel windows.
     ChooseToplevel,
@@ -60,7 +60,7 @@ pub fn capture(
             let image = conn.screenshot(*region, cursor)?;
             Ok((image, ShotResult::Area))
         }
-        CaptureMode::Toplevel(name) => capture_toplevel_by_name(conn, name, cursor),
+        CaptureMode::Toplevel(name) => capture_toplevel_by_identifier(conn, name, cursor),
         CaptureMode::ChooseToplevel => capture_toplevel_interactive(conn, cursor),
         CaptureMode::Output(name) => capture_output_by_name(conn, name, cursor),
         CaptureMode::ChooseOutput => capture_output_interactive(conn, cursor),
@@ -93,21 +93,21 @@ fn capture_geometry(
     Ok((image, ShotResult::Area))
 }
 
-fn capture_toplevel_by_name(
+fn capture_toplevel_by_identifier(
     conn: &WayshotConnection,
-    name: &str,
+    identifier: &str,
     cursor: bool,
 ) -> Result<(image::DynamicImage, ShotResult)> {
     let toplevels = conn.get_all_toplevels();
     let toplevel = toplevels
         .iter()
         .filter(|t| t.active)
-        .find(|t| t.id_and_title() == name)
-        .ok_or_else(|| eyre::eyre!("No toplevel window matched '{name}'"))?;
+        .find(|t| t.identifier == identifier)
+        .ok_or_else(|| eyre::eyre!("No toplevel window matched '{identifier}'"))?;
     Ok((
         conn.screenshot_toplevel(toplevel, cursor)?,
         ShotResult::Toplevel {
-            name: name.to_string(),
+            identifier: identifier.to_string(),
         },
     ))
 }
@@ -126,7 +126,7 @@ fn capture_toplevel_interactive(
     Ok((
         conn.screenshot_toplevel(active[idx], cursor)?,
         ShotResult::Toplevel {
-            name: names[idx].clone(),
+            identifier: names[idx].clone(),
         },
     ))
 }

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
         }
         Command::ListToplevels => {
             for tl in connection.get_all_toplevels().iter().filter(|t| t.active) {
-                writeln!(writer, "{}", tl.id_and_title())?;
+                writeln!(writer, "{}", tl.id_title_identifier())?;
             }
             writer.flush()?;
             Ok(())


### PR DESCRIPTION
resolve: https://github.com/waycrate/wayshot/issues/379

it is a breaking change, the origin logic is use id+title to choose a toplevel to shot, but the information is very verbose. Before I thought identifier is very random, so I did not use it to find the toplevel, but we can also print the identifier with list-toplevels, so I also modified that part to show the identifier information