### PR TITLE
nix: Remove invalid changelog from flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,6 @@
             meta = {
               description = "Screenshot crate for wlroots based compositors implementing the zwlr_screencopy_v1 protocol.";
               homepage = "https://crates.io/crates/wayshot";
-              changelog = "https://github.com/waycrate/wayshot/releases/tag/v${finalAttrs.version}";
               license = with lib.licenses; [
                 bsd2
                 gpl3Only


### PR DESCRIPTION
Since this is the Git version, there aren't really changelogs. Previous changelog field was pointing to an invalid release anyway