### PR TITLE
feat: add nix module & repackage with feature flags

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,21 @@
+name: Nix Checks
+
+on: [push, pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+
+      - name: Check flake evaluation
+        run: nix flake check --no-build --all-systems
+
+      - name: Check formatting
+        run: nix fmt -- --check .
+
+      - name: Check build
+        run: nix build

--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ Alternatively, set `stdout = true` in your config file to always write to stdout
 
 `wayshot-git` & `wayshot-bin` have been packaged.
 
+## Nix:
+
+Release builds available in nixpkgs.
+For git version and module [follow instructions](./nix/INSTALL.md)
+
 ## Compile time dependencies:
 
 - scdoc (If present, man-pages will be generated.)

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774709303,
-        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
+        "lastModified": 1784007870,
+        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
+        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,84 +1,35 @@
 {
+  description = "wayshot";
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs =
-    { self, nixpkgs }:
-    let
-      forAllSystems =
-        callback:
-        nixpkgs.lib.genAttrs [
-          "x86_64-linux"
-          "aarch64-linux"
-        ] (system: callback nixpkgs.legacyPackages.${system});
+  outputs = inputs @ {
+    self,
+    nixpkgs,
+    ...
+  }: let
+    forAllSystems = callback:
+      nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+      ] (system: callback nixpkgs.legacyPackages.${system});
+  in {
+    packages = forAllSystems (pkgs: rec {
+      default = wayshot;
+      wayshot = pkgs.callPackage ./nix/package.nix {};
+    });
 
-      mkDeps =
-        pkgs: with pkgs; [
-          pango
-          libgbm
-          libGL
-          wayland
-        ];
-    in
-    {
-      packages = forAllSystems (
-        pkgs:
-        let
-          inherit (pkgs) lib stdenv;
-        in
-        {
-          default = pkgs.rustPlatform.buildRustPackage (finalAttrs: {
-            pname = "wayshot";
-            version = "${(builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version}-git";
-            src = ./.;
-            cargoLock.lockFile = ./Cargo.lock;
-            nativeBuildInputs = with pkgs; [
-              pkg-config
-              installShellFiles
-            ];
-            buildInputs = mkDeps pkgs;
+    devShells = forAllSystems (pkgs: {
+      default = pkgs.callPackage ./nix/shell.nix {};
+    });
 
-            postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-              installManPage docs/wayshot.1.scd docs/wayshot.5.scd docs/wayshot.7.scd
-              installShellCompletion --cmd wayshot \
-                --bash <($out/bin/wayshot --completions bash) \
-                --fish <($out/bin/wayshot --completions fish) \
-                --zsh <($out/bin/wayshot --completions zsh)
-            '';
-
-            meta = {
-              description = "Screenshot crate for wlroots based compositors implementing the zwlr_screencopy_v1 protocol.";
-              homepage = "https://crates.io/crates/wayshot";
-              license = with lib.licenses; [
-                bsd2
-                gpl3Only
-              ];
-              mainProgram = "wayshot";
-              platforms = lib.platforms.linux;
-            };
-          });
-        }
-      );
-
-      devShells.default = forAllSystems (
-        pkgs:
-        let
-          inherit (pkgs) lib;
-        in
-        pkgs.mkShell {
-          strictDeps = true;
-          nativeBuildInputs = with pkgs; [
-            cargo
-            rustc
-            rust-analyzer
-            clippy
-            rustfmt
-            pkg-config
-          ];
-          buildInputs = mkDeps pkgs;
-          LD_LIBRARY_PATH = lib.makeLibraryPath (mkDeps pkgs);
-        }
-      );
+    overlays.default = final: prev: {
+      wayshot = final.callPackage ./nix/package.nix {};
     };
+
+    homeModules.default = import ./nix/module.nix {inherit self;};
+    formatter.x86_64-linux = inputs.nixpkgs.legacyPackages.x86_64-linux.alejandra;
+  };
 }

--- a/nix/INSTALL.md
+++ b/nix/INSTALL.md
@@ -1,0 +1,75 @@
+# Nix installation
+
+Flake users only. Add wayshot as an input:
+
+```nix
+{
+  inputs.wayshot.url = "github:waycrate/wayshot";
+}
+```
+
+- [Package overlay](#package-overlay)
+- [Home Manager module](#home-manager-module)
+
+## Package overlay
+
+Overlay for manual management of wayshot
+
+```nix
+{ inputs, pkgs, ... }:
+{
+  nixpkgs.overlays = [ inputs.wayshot.overlays.default ];
+
+  environment.systemPackages = [ pkgs.wayshot ];
+  # or in home-manager:
+  # home.packages = [ pkgs.wayshot ];
+}
+```
+
+Build features can be toggled via override (defaults match the crate's
+default feature set, see [package.nix](./package.nix) for the full list):
+
+```nix
+pkgs.wayshot.override {
+  webpSupport = false;
+  avifSupport = false;
+}
+```
+
+## Home Manager module
+
+Import the module in any of your home-manager config files:
+
+```nix
+{ inputs, ... }:
+{
+  imports = [
+    inputs.wayshot.homeModules.default
+  ];
+  ...
+}
+```
+
+### Configuration
+
+```nix
+{
+  programs.wayshot = {
+    enable = true;
+    # Build features ignored when `package` is set.
+    features = {
+      jxlSupport = false;
+    };
+    settings = {
+      base = {
+        cursor = true;
+        clipboard = false;
+        file = true;
+      };
+      file = {
+        path = "~/Pictures";
+      };
+    };
+  };
+}
+```

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,63 @@
+{self}: {
+  config,
+  options,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.programs.wayshot;
+  inherit (pkgs.stdenv.hostPlatform) system;
+  inherit (lib) types;
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkOption mkEnableOption;
+
+  tomlFormat = pkgs.formats.toml {};
+in {
+  options.programs.wayshot = {
+    enable = mkEnableOption "wayshot, a screenshot tool for wlroots based compositors";
+
+    package = mkOption {
+      description = "The package to use for `wayshot`";
+      default = self.packages.${system}.default.override cfg.features;
+      defaultText = "wayshot from this flake, with `features` applied";
+      type = types.package;
+    };
+
+    features = mkOption {
+      description = ''
+        Build-feature arguments passed to the default package via `.override`,
+        e.g. `{ webpSupport = false; }` (see nix/package.nix for the full list).
+        Only takes effect while `package` is left at its default.
+      '';
+      default = {};
+      type = types.attrsOf types.bool;
+    };
+
+    settings = mkOption {
+      description = "Configuration written to wayshot's `config.toml`.";
+      default = {};
+      type = tomlFormat.type;
+      example = {
+        base = {
+          cursor = true;
+          clipboard = true;
+        };
+        file = {
+          path = "~/Pictures";
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    warnings =
+      lib.optional
+      (cfg.features != {} && options.programs.wayshot.package.highestPrio < (lib.mkOptionDefault null).priority)
+      "programs.wayshot.features is ignored because programs.wayshot.package is set explicitly.";
+
+    home.packages = [cfg.package];
+    xdg.configFile."wayshot/config.toml" = mkIf (cfg.settings != {}) {
+      source = tomlFormat.generate "config.toml" cfg.settings;
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  pkg-config,
+  installShellFiles,
+  pango,
+  libgbm,
+  libGL,
+  wayland,
+  jpegSupport ? true,
+  pnmSupport ? true,
+  qoiSupport ? true,
+  webpSupport ? true,
+  avifSupport ? true,
+  jxlSupport ? true,
+  clipboardSupport ? true,
+  colorPickerSupport ? true,
+  completionsSupport ? true,
+  loggerSupport ? true,
+  notificationsSupport ? true,
+  selectorSupport ? true,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "wayshot";
+  version = "${(builtins.fromTOML (builtins.readFile (src + "/Cargo.toml"))).workspace.package.version}-git";
+
+  src = lib.cleanSource ../.;
+
+  cargoLock.lockFile = "${src}/Cargo.lock";
+
+  buildNoDefaultFeatures = true;
+  buildFeatures =
+    lib.optional jpegSupport "jpeg"
+    ++ lib.optional pnmSupport "pnm"
+    ++ lib.optional qoiSupport "qoi"
+    ++ lib.optional webpSupport "webp"
+    ++ lib.optional avifSupport "avif"
+    ++ lib.optional jxlSupport "jxl"
+    ++ lib.optional clipboardSupport "clipboard"
+    ++ lib.optional colorPickerSupport "color_picker"
+    ++ lib.optional completionsSupport "completions"
+    ++ lib.optional loggerSupport "logger"
+    ++ lib.optional notificationsSupport "notifications"
+    ++ lib.optional selectorSupport "selector";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    pango
+    libgbm
+    libGL
+    wayland
+  ];
+
+  postInstall = lib.optionalString (completionsSupport && stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installManPage docs/wayshot.1.scd docs/wayshot.5.scd docs/wayshot.7.scd
+    installShellCompletion --cmd wayshot \
+      --bash <($out/bin/wayshot --completions bash) \
+      --fish <($out/bin/wayshot --completions fish) \
+      --zsh <($out/bin/wayshot --completions zsh) \
+      --nushell <($out/bin/wayshot --completions nushell)
+  '';
+
+  meta = {
+    description = "Screenshot crate for wlroots based compositors implementing the zwlr_screencopy_v1 protocol.";
+    homepage = "https://crates.io/crates/wayshot";
+    license = with lib.licenses; [
+      gpl3Only
+    ];
+    mainProgram = "wayshot";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,25 @@
+{pkgs}: let
+  deps = with pkgs; [
+    pango
+    libgbm
+    libGL
+    wayland
+  ];
+in
+  pkgs.mkShell {
+    name = "wayshot-dev-shell";
+    strictDeps = true;
+    nativeBuildInputs = with pkgs; [
+      # Compilers
+      cargo
+      rustc
+
+      # Tools
+      pkg-config
+      clippy
+      rust-analyzer
+      rustfmt
+    ];
+    buildInputs = deps;
+    LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath deps;
+  }


### PR DESCRIPTION
What's done:
- add home manager module
- repackage to add support for build features with defaulting to one in repo
- move shell, package away from flake
- bump lock
- workflow with checks for nix eval, build & fmt

Why:
- toml is well supported format in nix, so nice to have a module
- move packaging and shell away from flake as it grew too big with module
- regarding features disabled when package is set - if user uses package from nixpkgs no features there present at least for now

ps. 
I thought about adding a regular module, not home manager. But it would require either changing wayshot code to support multiple `--config` flags and default to last one or create an ugly wrapper for that. That's why that idea on hold for now.