### PR TITLE
fix: separate dmabuf-related features on libwayshot side

### DIFF
--- a/libwayshot/Cargo.toml
+++ b/libwayshot/Cargo.toml
@@ -15,8 +15,9 @@ jpeg = ["image/jpeg"]
 qoi = ["image/qoi"]
 webp = ["image/webp"]
 avif = ["image/avif"]
-egl = ["dep:gl", "dep:r-egl-wayland"]
-screencast = []
+dmabuf = ["dep:gbm", "dep:drm"]
+egl = ["dep:gl", "dep:r-egl-wayland", "dmabuf"]
+screencast = ["dmabuf"]
 
 [dependencies]
 tracing.workspace = true
@@ -34,8 +35,8 @@ wayland-protocols = { workspace = true, features = [
 wayland-protocols-wlr = { version = "0.3", features = ["client"] }
 wayland-backend = { version = "0.3", features = ["client_system"] }
 
-gbm = "0.18"
-drm = "0.15"
+gbm = { version = "0.18", optional = true }
+drm = { version = "0.15", optional = true }
 
 gl = { workspace = true, optional = true }
 r-egl-wayland = { workspace = true, optional = true }

--- a/libwayshot/src/dispatch.rs
+++ b/libwayshot/src/dispatch.rs
@@ -1,9 +1,13 @@
+#[cfg(feature = "dmabuf")]
 use drm::node::DrmNode;
 use std::{
     collections::HashSet,
+    sync::atomic::{AtomicBool, Ordering},
+};
+#[cfg(feature = "dmabuf")]
+use std::{
     os::fd::{AsFd, BorrowedFd},
     path::Path,
-    sync::atomic::{AtomicBool, Ordering},
 };
 use wayland_client::{
     Connection, Dispatch, QueueHandle,
@@ -213,7 +217,9 @@ pub struct CaptureFrameState {
     pub buffer_done: AtomicBool,
     pub toplevels: Vec<TopLevel>,
     pub(crate) session_done: bool,
+    #[cfg(feature = "dmabuf")]
     pub(crate) gbm: Option<gbm::Device<Card>>,
+    #[cfg_attr(not(feature = "dmabuf"), allow(dead_code))]
     find_gbm: bool,
     session_size: Size,
 }
@@ -227,6 +233,7 @@ impl CaptureFrameState {
             buffer_done: AtomicBool::new(false),
             toplevels: Vec::new(),
             session_done: false,
+            #[cfg(feature = "dmabuf")]
             gbm: None,
             find_gbm,
             session_size: Size {
@@ -326,36 +333,43 @@ impl Dispatch<ExtImageCopyCaptureSessionV1, ()> for CaptureFrameState {
                 });
             }
             ext_image_copy_capture_session_v1::Event::DmabufDevice { device } => {
-                if !state.find_gbm {
-                    return;
-                }
-                // Handle potential malformed data from compositor
-                let device = match device.try_into() {
-                    Ok(bytes) => u64::from_le_bytes(bytes),
-                    Err(_) => {
-                        tracing::warn!(
-                            "Received invalid device data from compositor (expected 8 bytes)"
-                        );
+                #[cfg(feature = "dmabuf")]
+                {
+                    if !state.find_gbm {
                         return;
                     }
-                };
-                let Ok(node) = DrmNode::from_dev_id(device) else {
-                    tracing::warn!("Failed to create DRM node from device ID: {}", device);
-                    return;
-                };
-                let Some(pa) = node.dev_path() else {
-                    tracing::warn!("DRM node has no device path");
-                    return;
-                };
-                let Ok(card) = Card::open(&pa) else {
-                    tracing::warn!("Failed to open DRM card at {:?}", pa);
-                    return;
-                };
-                let Ok(gbm) = gbm::Device::new(card) else {
-                    tracing::warn!("Failed to create GBM device");
-                    return;
-                };
-                state.gbm = Some(gbm);
+                    // Handle potential malformed data from compositor
+                    let device = match device.try_into() {
+                        Ok(bytes) => u64::from_le_bytes(bytes),
+                        Err(_) => {
+                            tracing::warn!(
+                                "Received invalid device data from compositor (expected 8 bytes)"
+                            );
+                            return;
+                        }
+                    };
+                    let Ok(node) = DrmNode::from_dev_id(device) else {
+                        tracing::warn!("Failed to create DRM node from device ID: {}", device);
+                        return;
+                    };
+                    let Some(pa) = node.dev_path() else {
+                        tracing::warn!("DRM node has no device path");
+                        return;
+                    };
+                    let Ok(card) = Card::open(&pa) else {
+                        tracing::warn!("Failed to open DRM card at {:?}", pa);
+                        return;
+                    };
+                    let Ok(gbm) = gbm::Device::new(card) else {
+                        tracing::warn!("Failed to create GBM device");
+                        return;
+                    };
+                    state.gbm = Some(gbm);
+                }
+                #[cfg(not(feature = "dmabuf"))]
+                {
+                    let _ = device;
+                }
             }
             ext_image_copy_capture_session_v1::Event::DmabufFormat { format, .. } => {
                 state.dmabuf_formats.push(DMAFrameFormat {
@@ -543,18 +557,22 @@ impl wayland_client::Dispatch<ZwlrLayerSurfaceV1, WlOutput> for LayerShellState 
         }
     }
 }
+#[cfg(feature = "dmabuf")]
 pub(crate) struct Card(std::fs::File);
 
 /// Implementing [`AsFd`] is a prerequisite to implementing the traits found
 /// in this crate. Here, we are just calling [`File::as_fd()`] on the inner
 /// [`File`].
+#[cfg(feature = "dmabuf")]
 impl AsFd for Card {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.0.as_fd()
     }
 }
+#[cfg(feature = "dmabuf")]
 impl drm::Device for Card {}
 /// Simple helper methods for opening a `Card`.
+#[cfg(feature = "dmabuf")]
 impl Card {
     pub fn open<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
         let mut options = std::fs::OpenOptions::new();
@@ -564,6 +582,7 @@ impl Card {
     }
 }
 #[derive(Debug)]
+#[cfg(feature = "dmabuf")]
 pub(crate) struct DMABUFState {
     pub linux_dmabuf: ZwpLinuxDmabufV1,
     pub gbmdev: gbm::Device<Card>,

--- a/libwayshot/src/egl.rs
+++ b/libwayshot/src/egl.rs
@@ -124,6 +124,7 @@ pub fn bind_egl_image_to_gl_texture(guard: &EGLImageGuard) -> Result<()> {
 
 /// Create an EGLImage from the DMA-BUF and bind it to the current GL texture, then destroy the EGLImage.
 /// Used by screencast when updating the texture each frame.
+#[cfg(feature = "screencast")]
 pub fn create_egl_image_and_bind_to_gl_texture(
     egl_display: egl::Display,
     bo: &BufferObject<()>,

--- a/libwayshot/src/error.rs
+++ b/libwayshot/src/error.rs
@@ -1,6 +1,8 @@
 use std::{io, result};
 
+#[cfg(feature = "dmabuf")]
 use drm::buffer::UnrecognizedFourcc;
+#[cfg(feature = "dmabuf")]
 use gbm::InvalidFdError;
 #[cfg(feature = "egl")]
 use r_egl_wayland::r_egl as egl;
@@ -45,6 +47,7 @@ pub enum Error {
         "dmabuf configuration not initialized. Did you not use Wayshot::from_connection_with_dmabuf()?"
     )]
     NoDMAStateError,
+    #[cfg(feature = "dmabuf")]
     #[error("dmabuf color format provided by compositor is invalid")]
     UnrecognizedColorCode(#[from] UnrecognizedFourcc),
     #[cfg(feature = "egl")]
@@ -57,6 +60,7 @@ pub enum Error {
     CaptureFailed(String),
     #[error("Unsupported for some reason: {0}")]
     Unsupported(String),
+    #[cfg(feature = "dmabuf")]
     #[error("Fd does not exist")]
     InvalidFd(#[from] InvalidFdError),
 }

--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -18,17 +18,20 @@ mod screencopy;
 #[cfg(test)]
 mod tests;
 
+#[cfg(feature = "dmabuf")]
+use std::path::Path;
 use std::{
-    cell::RefCell, collections::HashSet, fs::File, os::fd::AsFd, path::Path,
-    sync::atomic::Ordering, thread,
+    cell::RefCell, collections::HashSet, fs::File, os::fd::AsFd, sync::atomic::Ordering, thread,
 };
 
-use dispatch::{DMABUFState, LayerShellState};
+#[cfg(feature = "dmabuf")]
+use dispatch::DMABUFState;
+use dispatch::LayerShellState;
 use image::DynamicImage;
 use memmap2::MmapMut;
-use screencopy::{
-    DMAFrameFormat, DMAFrameGuard, FrameCopy, FrameData, FrameFormat, FrameGuard, create_shm_fd,
-};
+#[cfg(feature = "dmabuf")]
+use screencopy::{DMAFrameFormat, DMAFrameGuard};
+use screencopy::{FrameCopy, FrameData, FrameFormat, FrameGuard, create_shm_fd};
 use tracing::debug;
 use wayland_client::{
     Connection, EventQueue, Proxy,
@@ -38,6 +41,10 @@ use wayland_client::{
         wl_output::{Transform, WlOutput},
         wl_shm::{self, WlShm},
     },
+};
+#[cfg(feature = "dmabuf")]
+use wayland_protocols::wp::linux_dmabuf::zv1::client::{
+    zwp_linux_buffer_params_v1, zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1,
 };
 use wayland_protocols::{
     ext::{
@@ -54,12 +61,7 @@ use wayland_protocols::{
             ext_image_copy_capture_manager_v1::{ExtImageCopyCaptureManagerV1, Options},
         },
     },
-    wp::{
-        linux_dmabuf::zv1::client::{
-            zwp_linux_buffer_params_v1, zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1,
-        },
-        viewporter::client::wp_viewporter::WpViewporter,
-    },
+    wp::viewporter::client::wp_viewporter::WpViewporter,
     xdg::xdg_output::zv1::client::{
         zxdg_output_manager_v1::ZxdgOutputManagerV1, zxdg_output_v1::ZxdgOutputV1,
     },
@@ -94,6 +96,7 @@ pub mod reexport {
     pub use wl_output::{Transform, WlOutput};
     pub use wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1;
 }
+#[cfg(feature = "dmabuf")]
 use gbm::{BufferObject, BufferObjectFlags, Device as GBMDevice};
 
 /// Struct to store wayland connection and globals list.
@@ -110,9 +113,11 @@ pub struct WayshotConnection {
     pub globals: GlobalList,
     output_infos: Vec<OutputInfo>,
     toplevel_infos: Vec<TopLevel>,
+    #[cfg(feature = "dmabuf")]
     dmabuf_state: Option<DMABUFState>,
     toplevel_capture_support: bool,
     image_copy_support: bool,
+    #[cfg(feature = "dmabuf")]
     find_dmabuf: bool,
     registers: WayshotRegisters,
 }
@@ -303,9 +308,11 @@ impl WayshotConnection {
             globals,
             output_infos: Vec::new(),
             toplevel_infos: Vec::new(),
+            #[cfg(feature = "dmabuf")]
             dmabuf_state: None,
             toplevel_capture_support: false,
             image_copy_support: false,
+            #[cfg(feature = "dmabuf")]
             find_dmabuf: false,
             registers,
         };
@@ -318,19 +325,30 @@ impl WayshotConnection {
         Ok(initial_state)
     }
 
+    #[cfg(feature = "dmabuf")]
     fn has_gbm(&self) -> bool {
         self.dmabuf_state.is_some()
     }
 
     // NOTE: this function says if we need to try receive the gdm information from ext-image-copy
+    #[cfg(feature = "dmabuf")]
     fn need_try_find_gbm(&self) -> bool {
         !self.has_gbm() && self.find_dmabuf
     }
+
+    // Without the `dmabuf` feature there is no GBM/DRM device to negotiate, so we never
+    // need to ask the compositor for dmabuf device information.
+    #[cfg(not(feature = "dmabuf"))]
+    fn need_try_find_gbm(&self) -> bool {
+        false
+    }
+
     ///Create a WayshotConnection struct having DMA-BUF support
     /// Using this connection is required to make use of the dmabuf functions
     ///# Parameters
     /// - conn: a Wayland connection
     /// - device_path: string pointing to the DRI device that is to be used for creating the DMA-BUFs on. For example: "/dev/dri/renderD128"
+    #[cfg(feature = "dmabuf")]
     pub fn from_connection_with_dmabuf<P: AsRef<Path>>(
         conn: Connection,
         device_path: P,
@@ -652,6 +670,7 @@ impl WayshotConnection {
     ///   a guard to manage the frame's lifecycle, and the GPU-backed `BufferObject`.
     /// # Errors
     /// - Returns `NoDMAStateError` if the DMA-BUF state is not initialized a the time of initialization of this struct.
+    #[cfg(feature = "dmabuf")]
     pub fn capture_target_frame_dmabuf(
         &self,
         target: &WayshotTarget,
@@ -852,6 +871,7 @@ impl WayshotConnection {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "dmabuf")]
     fn capture_output_frame_inner_dmabuf<T: AsFd>(
         &self,
         state: CaptureFrameState,
@@ -882,6 +902,7 @@ impl WayshotConnection {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "dmabuf")]
     fn ext_image_copy_frame_dmabuf_inner<T: AsFd>(
         &self,
         mut state: CaptureFrameState,
@@ -955,6 +976,7 @@ impl WayshotConnection {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[cfg(feature = "dmabuf")]
     fn capture_output_frame_inner_dmabuf_wlr<T: AsFd>(
         &self,
         mut state: CaptureFrameState,

--- a/libwayshot/src/screencopy.rs
+++ b/libwayshot/src/screencopy.rs
@@ -4,6 +4,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+#[cfg(feature = "dmabuf")]
 use gbm::BufferObject;
 use image::{ColorType, DynamicImage, ImageBuffer, Pixel, Rgba};
 use memmap2::MmapMut;
@@ -34,9 +35,11 @@ impl Drop for FrameGuard {
     }
 }
 
+#[cfg(feature = "dmabuf")]
 pub struct DMAFrameGuard {
     pub buffer: WlBuffer,
 }
+#[cfg(feature = "dmabuf")]
 impl Drop for DMAFrameGuard {
     fn drop(&mut self) {
         self.buffer.destroy();
@@ -93,6 +96,7 @@ where
 #[derive(Debug)]
 pub enum FrameData {
     Mmap(MmapMut),
+    #[cfg(feature = "dmabuf")]
     GBMBo(BufferObject<()>),
 }
 /// The copied frame comprising of the FrameFormat, ColorType (Rgba8), and a memory backed shm
@@ -116,6 +120,7 @@ impl FrameCopy {
         }
         let frame_color_type = match create_converter(self.frame_format.format) {
             Some(converter) => {
+                #[cfg_attr(not(feature = "dmabuf"), allow(irrefutable_let_patterns))]
                 let FrameData::Mmap(raw) = &mut self.frame_data else {
                     return Err(Error::InvalidColor);
                 };
@@ -142,6 +147,7 @@ impl FrameCopy {
 
         match self.frame_data {
             FrameData::Mmap(frame_mmap) => create_image_buffer(&self.frame_format, frame_mmap),
+            #[cfg(feature = "dmabuf")]
             FrameData::GBMBo(_) => todo!(),
         }
     }
@@ -161,6 +167,7 @@ impl TryFrom<&FrameCopy> for DynamicImage {
             ColorType::Rgb8 => {
                 let frame_data = match &value.frame_data {
                     FrameData::Mmap(frame_mmap) => frame_mmap.to_vec(),
+                    #[cfg(feature = "dmabuf")]
                     FrameData::GBMBo(_) => todo!(),
                 };
                 Self::ImageRgb8(create_image_buffer(&value.frame_format, frame_data)?)
@@ -168,6 +175,7 @@ impl TryFrom<&FrameCopy> for DynamicImage {
             ColorType::Rgba8 => {
                 let frame_data = match &value.frame_data {
                     FrameData::Mmap(frame_mmap) => frame_mmap.to_vec(),
+                    #[cfg(feature = "dmabuf")]
                     FrameData::GBMBo(_) => todo!(),
                 };
                 Self::ImageRgba8(create_image_buffer(&value.frame_format, frame_data)?)


### PR DESCRIPTION
As discussed in: https://github.com/waycrate/wayshot/pull/390#discussion_r3603549139, separated features since we don't need to depend on that stuff in all scenarios and on `wayshot` binary side.