### PR TITLE
fix: guards & build with --no-default-features --all-targets flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
             matrix:
                 include:
                     - name: all-features
-                      cargo_args: --workspace --release --all-features
+                      cargo_args: --workspace --release --all-features --all-targets
                     - name: default
-                      cargo_args: --workspace --release
+                      cargo_args: --workspace --release --all-targets
                     - name: minimal
-                      cargo_args: --workspace --release --no-default-features
+                      cargo_args: --workspace --release --no-default-features --all-targets
 
         name: ${{ matrix.name }}
         runs-on: ubuntu-latest

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,6 +2,9 @@ name: Nix Checks
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/libwayshot/Cargo.toml
+++ b/libwayshot/Cargo.toml
@@ -19,6 +19,10 @@ dmabuf = ["dep:gbm", "dep:drm"]
 egl = ["dep:gl", "dep:r-egl-wayland", "dmabuf"]
 screencast = ["dmabuf"]
 
+[[example]]
+name = "waymirror"
+required-features = ["screencast"]
+
 [dependencies]
 tracing.workspace = true
 image.workspace = true

--- a/libwayshot/src/tests/dispatch.rs
+++ b/libwayshot/src/tests/dispatch.rs
@@ -1,7 +1,9 @@
-use crate::dispatch::{CaptureFrameState, Card};
+use crate::dispatch::CaptureFrameState;
 
+#[cfg(feature = "dmabuf")]
 #[test]
 fn card_open_nonexistent_path_errors() {
+    use crate::dispatch::Card;
     let err = Card::open("/nonexistent/dri/renderD999").err().unwrap();
     assert!(err.kind() == std::io::ErrorKind::NotFound);
 }

--- a/libwayshot/src/tests/error.rs
+++ b/libwayshot/src/tests/error.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+#[cfg(feature = "dmabuf")]
 use drm::buffer::UnrecognizedFourcc;
 use wayland_client::{
     ConnectError, DispatchError,
@@ -174,6 +175,7 @@ fn test_display_no_dma_state_error() {
     assert_eq!(err.to_string(), expected_msg);
 }
 
+#[cfg(feature = "dmabuf")]
 #[test]
 fn test_from_unrecognised_fourcc() {
     let fourcc_error = UnrecognizedFourcc(42);


### PR DESCRIPTION
fix: guards & build with --no-default-features --all-targets flags