### PR TITLE
chore(api)!: remove print_displays_info from libwayshot

### DIFF
--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -453,35 +453,6 @@ impl WayshotConnection {
         Ok(())
     }
 
-    /// print the displays' info
-    pub fn print_displays_info(&self) {
-        for OutputInfo {
-            physical_size: Size { width, height },
-            logical_region:
-                LogicalRegion {
-                    inner:
-                        region::Region {
-                            position: region::Position { x, y },
-                            size:
-                                Size {
-                                    width: logical_width,
-                                    height: logical_height,
-                                },
-                        },
-                },
-            name,
-            description,
-            ..
-        } in self.get_all_outputs()
-        {
-            println!("{name}");
-            println!("description: {description}");
-            println!("    Size: {width},{height}");
-            println!("    LogicSize: {logical_width}, {logical_height}");
-            println!("    Position: {x}, {y}");
-        }
-    }
-
     /// Query which `wl_shm::Format` the compositor supports for this output by performing a trial screenshot through wlr-screencopy protocol.
     /// # Parameters
     /// - `output`: Reference to the [WayshotTarget] to inspect.

--- a/wayshot/src/wayshot.rs
+++ b/wayshot/src/wayshot.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use clap::Parser;
 use eyre::Result;
-use libwayshot::WayshotConnection;
+use libwayshot::{LogicalRegion, OutputInfo, Size, WayshotConnection, region};
 
 mod cli;
 #[cfg(feature = "clipboard")]
@@ -21,6 +21,35 @@ mod utils;
 
 use config::Config;
 use settings::{AppSettings, Command};
+
+/// print the displays' info
+pub fn print_displays_info(conn: &WayshotConnection) {
+    for OutputInfo {
+        physical_size: Size { width, height },
+        logical_region:
+            LogicalRegion {
+                inner:
+                    region::Region {
+                        position: region::Position { x, y },
+                        size:
+                            Size {
+                                width: logical_width,
+                                height: logical_height,
+                            },
+                    },
+            },
+        name,
+        description,
+        ..
+    } in conn.get_all_outputs()
+    {
+        println!("{name}");
+        println!("description: {description}");
+        println!("    Size: {width},{height}");
+        println!("    LogicSize: {logical_width}, {logical_height}");
+        println!("    Position: {x}, {y}");
+    }
+}
 
 fn main() -> Result<()> {
     let cli = cli::Cli::parse();
@@ -52,7 +81,7 @@ fn main() -> Result<()> {
             Ok(())
         }
         Command::ListOutputsInfo => {
-            connection.print_displays_info();
+            print_displays_info(&connection);
             Ok(())
         }
         Command::ListToplevels => {


### PR DESCRIPTION
libwayshot should not do something like printing something, this logic should be moved to wayshot

as mentioned in https://github.com/waycrate/wayshot/pull/387#issuecomment-5020923062