### PR TITLE
fix: allow negative coordinates in geometry string

### DIFF
--- a/wayshot/src/cli.rs
+++ b/wayshot/src/cli.rs
@@ -104,7 +104,7 @@ pub struct Cli {
     /// Without a value: interactively select a region (requires the `selector` feature).
     /// With a value: parse the geometry string in slurp/grim format "x,y widthxheight".
     ///   Example: wayshot -g "$(slurp)" or wayshot -g "783,746 177x251"
-    #[arg(short, long, value_name = "GEOMETRY", num_args = 0..=1, verbatim_doc_comment)]
+    #[arg(short, long, allow_hyphen_values = true, value_name = "GEOMETRY", num_args = 0..=1, verbatim_doc_comment)]
     pub geometry: Option<Option<String>>,
 
     /// Background color (rgba hex) while selecting a region (geometry).


### PR DESCRIPTION
## Summary

Allow hyphen prefixed values for the `--geometry` argument so that negative coordinates are parsed correctly.

Previously, commands such as:

```bash
wayshot -g "-100,-100 200x200"
```

would fail to parse due to the leading hyphen being treated as an unknown CLI flag. This fix allows signed integers in geometry strings, which is required for multi-monitor setups (e.g., in Hyprland) where displays are positioned to the left or top of the primary monitor.

Fixes #413 