### PR TITLE
fix: prefer the transform by ext-image-copy

### DIFF
--- a/libwayshot/src/dispatch.rs
+++ b/libwayshot/src/dispatch.rs
@@ -217,6 +217,7 @@ pub struct CaptureFrameState {
     pub buffer_done: AtomicBool,
     pub toplevels: Vec<TopLevel>,
     pub(crate) session_done: bool,
+    pub transform: Option<wl_output::Transform>,
     #[cfg(feature = "dmabuf")]
     pub(crate) gbm: Option<gbm::Device<Card>>,
     #[cfg_attr(not(feature = "dmabuf"), allow(dead_code))]
@@ -233,6 +234,7 @@ impl CaptureFrameState {
             buffer_done: AtomicBool::new(false),
             toplevels: Vec::new(),
             session_done: false,
+            transform: None,
             #[cfg(feature = "dmabuf")]
             gbm: None,
             find_gbm,
@@ -286,7 +288,11 @@ impl Dispatch<ExtImageCopyCaptureFrameV1, ()> for CaptureFrameState {
                 state.buffer_done.store(true, Ordering::Relaxed);
                 state.state = Some(FrameState::FailedWithReason(reason));
             }
-            ext_image_copy_capture_frame_v1::Event::Transform { .. } => {}
+            ext_image_copy_capture_frame_v1::Event::Transform {
+                transform: WEnum::Value(transform),
+            } => {
+                state.transform = Some(transform);
+            }
             _ => {}
         }
     }

--- a/libwayshot/src/lib.rs
+++ b/libwayshot/src/lib.rs
@@ -1138,6 +1138,7 @@ impl WayshotConnection {
                             buffer,
                             shm_pool,
                             size: frame_format.size,
+                            transform: state.transform,
                         });
                     }
                 }
@@ -1202,6 +1203,7 @@ impl WayshotConnection {
                             buffer,
                             shm_pool,
                             size: frame_format.size,
+                            transform: state.transform,
                         });
                     }
                 }
@@ -1246,7 +1248,7 @@ impl WayshotConnection {
             frame_format,
             frame_color_type: image::ColorType::Rgb8,
             frame_data: FrameData::Mmap(frame_mmap),
-            transform: output_info.transform,
+            transform: frame_guard.transform.unwrap_or(output_info.transform),
             logical_region: capture_region
                 .map(|capture_region| capture_region.logical())
                 .unwrap_or(output_info.logical_region),
@@ -1579,7 +1581,7 @@ impl WayshotConnection {
         let fd = create_shm_fd()?;
         let memfile = File::from(fd);
         // Determine a suitable shm FrameFormat for this frame
-        let (frame_format, _) = self.capture_toplevel_frame_shm_from_file(
+        let (frame_format, guard) = self.capture_toplevel_frame_shm_from_file(
             cursor_overlay,
             toplevel.toplevel(),
             &memfile,
@@ -1591,7 +1593,7 @@ impl WayshotConnection {
             frame_format,
             frame_color_type: image::ColorType::Rgb8, // will be updated by get_image
             frame_data: FrameData::Mmap(frame_mmap),
-            transform: Transform::Normal,
+            transform: guard.transform.unwrap_or(Transform::Normal),
             logical_region: LogicalRegion {
                 inner: crate::region::Region {
                     position: crate::region::Position { x: 0, y: 0 },

--- a/libwayshot/src/screencopy.rs
+++ b/libwayshot/src/screencopy.rs
@@ -26,6 +26,7 @@ pub struct FrameGuard {
     pub buffer: WlBuffer,
     pub shm_pool: WlShmPool,
     pub size: Size,
+    pub transform: Option<wl_output::Transform>,
 }
 
 impl Drop for FrameGuard {


### PR DESCRIPTION
resolve: https://github.com/waycrate/wayshot/issues/359

before we use the transform by wl-output to address the final image, but it is wrong. now ext-image-copy provide us the real transform of the image, we need to use it first, if we have to use the wlr-screencopy, then we use the transform of the screen